### PR TITLE
Add code signing config for ARM64, change the naming of the Nuget

### DIFF
--- a/build/nuget/Microsoft.icu.icu4c.win.targets
+++ b/build/nuget/Microsoft.icu.icu4c.win.targets
@@ -9,10 +9,12 @@
           v142 is the Visual Studio 2019 toolset.
     -->
     <Link>
-      <!-- Note: The ICU VS Solutions use the convention 'Win32'=='x86', so we use that that here as well. -->
+      <AdditionalDependencies Condition="'$(Platform)' == 'ARM64'">$(MSBuildThisFileDirectory)lib\ARM64\Release\icudt.lib;$(MSBuildThisFileDirectory)lib\ARM64\Release\icuuc.lib;$(MSBuildThisFileDirectory)lib\ARM64\Release\icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)lib\x64\Release\icudt.lib;$(MSBuildThisFileDirectory)lib\x64\Release\icuuc.lib;$(MSBuildThisFileDirectory)lib\x64\Release\icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!-- Note: The ICU VS Solutions use the convention 'Win32'=='x86', so we use that that here as well. -->
       <AdditionalDependencies Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'Win32'">$(MSBuildThisFileDirectory)lib\x86\Release\icudt.lib;$(MSBuildThisFileDirectory)lib\x86\Release\icuuc.lib;$(MSBuildThisFileDirectory)lib\x86\Release\icuin.lib;%(AdditionalDependencies)</AdditionalDependencies>
 
+      <AdditionalLibraryDirectories Condition="'$(Platform)' == 'ARM64'">$(MSBuildThisFileDirectory)lib\ARM64\Release;%(AdditionalLibraryDirectories)</
       <AdditionalLibraryDirectories Condition="'$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)lib\x86\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'Win32'">$(MSBuildThisFileDirectory)lib\x86\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
@@ -22,6 +24,11 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <!-- Files to copy for runtime -->
+  <ItemGroup Condition="'$(Platform)' == 'ARM64'">
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\ARM64\native\icudt*.dll" />
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\ARM64\native\icuuc*.dll" />
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\ARM64\native\icuin*.dll" />
+  </ItemGroup>
   <ItemGroup Condition="'$(Platform)' == 'x64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\x64\native\icudt*.dll" />
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\x64\native\icuuc*.dll" />

--- a/build/nuget/SignConfig-ICU-Binaries.xml
+++ b/build/nuget/SignConfig-ICU-Binaries.xml
@@ -54,7 +54,39 @@
     <file src="__INPATHROOT__\uconv.exe"    signType="AuthenticodeFormer" />
 
     <!-- DLLs -->
+    <!-- Data library -->
+    <file src="__INPATHROOT__\icudt*.dll" signType="AuthenticodeFormer" />
+    <!-- Common library -->
+    <file src="__INPATHROOT__\icuuc*.dll" signType="AuthenticodeFormer" />
+    <!-- i18n library -->
+    <file src="__INPATHROOT__\icuin*.dll" signType="AuthenticodeFormer" />
+    <!-- IO library -->
+    <file src="__INPATHROOT__\icuio*.dll" signType="AuthenticodeFormer" />
+    <!-- Tool Utilities library -->
+    <file src="__INPATHROOT__\icutu*.dll" signType="AuthenticodeFormer" />
+    <!-- Test Plug-in -->
+    <file src="__INPATHROOT__\testplug.dll" signType="AuthenticodeFormer" />
+  </job>
+  <job platform="ARM64" certSubject="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+    configuration="Release" dest="__OUTPATHROOT__\signed" jobname="Code Sign MS-ICU binaries (ARM64)" approvers="">
+    <!-- EXEs -->
+    <file src="__INPATHROOT__\derb.exe"     signType="AuthenticodeFormer" />
+    <file src="__INPATHROOT__\genbrk.exe"   signType="AuthenticodeFormer" />
+    <file src="__INPATHROOT__\genccode.exe" signType="AuthenticodeFormer" />
+    <file src="__INPATHROOT__\gencfu.exe"   signType="AuthenticodeFormer" />
+    <file src="__INPATHROOT__\gencmn.exe"   signType="AuthenticodeFormer" />
+    <file src="__INPATHROOT__\gencnval.exe" signType="AuthenticodeFormer" />
+    <file src="__INPATHROOT__\gendict.exe"  signType="AuthenticodeFormer" />
+    <file src="__INPATHROOT__\gennorm2.exe" signType="AuthenticodeFormer" />
+    <file src="__INPATHROOT__\genrb.exe"    signType="AuthenticodeFormer" />
+    <file src="__INPATHROOT__\gensprep.exe" signType="AuthenticodeFormer" />
+    <file src="__INPATHROOT__\icuinfo.exe"  signType="AuthenticodeFormer" />
+    <file src="__INPATHROOT__\icupkg.exe"   signType="AuthenticodeFormer" />
+    <file src="__INPATHROOT__\makeconv.exe" signType="AuthenticodeFormer" />
+    <file src="__INPATHROOT__\pkgdata.exe"  signType="AuthenticodeFormer" />
+    <file src="__INPATHROOT__\uconv.exe"    signType="AuthenticodeFormer" />
 
+    <!-- DLLs -->
     <!-- Data library -->
     <file src="__INPATHROOT__\icudt*.dll" signType="AuthenticodeFormer" />
     <!-- Common library -->

--- a/build/nuget/SignConfig-ICU-Nuget.xml
+++ b/build/nuget/SignConfig-ICU-Nuget.xml
@@ -3,7 +3,7 @@
 
   <job platform="AnyCPU" configuration="Release" certSubject="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
    dest="__OUTPATHROOT__\signed" jobname="Code Sign MS-ICU Nuget" approvers="">
-    <file src="__INPATHROOT__\Microsoft.icu4c.*.nupkg" signType="Nuget" />
+    <file src="__INPATHROOT__\Microsoft.icu.*.nupkg" signType="Nuget" />
   </job>
   
 </SignConfigXML>

--- a/build/nuget/Template-Microsoft.icu.icu4c.win.nuspec
+++ b/build/nuget/Template-Microsoft.icu.icu4c.win.nuspec
@@ -4,21 +4,22 @@
     <id>$id$</id>
     <version>$version$</version>
     <authors>Microsoft</authors>
-    <owners>Microsoft,msicu</owners>
     <license type="file">LICENSE</license>
     <projectUrl>https://github.com/microsoft/icu</projectUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <summary>Pre-built Windows binaries of ICU4C</summary>
-    <description>ICU4C is a mature, widely used set of C/C++ libraries providing Unicode and Globalization support for software applications.
+    <description>This package contains pre-built binaries of ICU4C for Windows from the Microsoft ICU (MS-ICU) repo on GitHub.
 
-This package contains pre-built binaries of ICU4C for Windows from the MS-ICU repo. MS-ICU is a modified version of ICU4C with changes for security purposes, maintenance, data changes for Microsoft usage, as well as minor changes for the Windows OS build of ICU4C.
+ICU4C is a mature, widely used set of C/C++ libraries providing Unicode and Globalization support for software applications.
+
+The MS-ICU repo contains a modified version of ICU4C with changes for security, maintenance, data changes for Microsoft usage, as well as minor changes for the Windows OS build of ICU4C.
 
 These binaries are built using the MSVC compiler and require the VC Redist to be installed.
 
 Note: In order to have binary compatibility between versions see: https://aka.ms/icu-binary-compatibility
     </description>
     <releaseNotes>https://aka.ms/ms-icu-nuget-release-notes</releaseNotes>
-    <copyright>Copyright Microsoft Corporation. All rights reserved.</copyright>
-    <tags>native nativepackage icu icu4c Unicode c++ cpp oss opensource</tags>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>native nativepackage icu icu4c</tags>
   </metadata>
 </package>

--- a/build/scripts/Create-Nuget.ps1
+++ b/build/scripts/Create-Nuget.ps1
@@ -99,12 +99,12 @@ Copy-Item $licenseFile -Destination "$outputNugetLocation\LICENSE"
 Copy-Item "$sourceRoot\build\nuget\*.targets" -Destination "$outputNugetLocation\build\native"
 
 # Update the placeholders in the template nuspec file.
-$nuspecFileContent = (Get-Content "$sourceRoot\build\nuget\Template-Microsoft.icu4c.win.nuspec")
-$nuspecFileContent = $nuspecFileContent.replace('$id$', 'Microsoft.icu4c.win')
+$nuspecFileContent = (Get-Content "$sourceRoot\build\nuget\Template-Microsoft.icu.icu4c.win.nuspec")
+$nuspecFileContent = $nuspecFileContent.replace('$id$', 'Microsoft.icu.icu4c.win')
 $nuspecFileContent = $nuspecFileContent.replace('$version$', $env:nugetPackageVersion)
-$nuspecFileContent | Set-Content "$outputNugetLocation\Microsoft.icu4c.win.nuspec"
+$nuspecFileContent | Set-Content "$outputNugetLocation\Microsoft.icu.icu4c.win.nuspec"
 
 # Actually do the "nuget pack" operation
-$nugetCmd = ("nuget pack $outputNugetLocation\Microsoft.icu4c.win.nuspec -BasePath $outputNugetLocation -OutputDirectory $output")
+$nugetCmd = ("nuget pack $outputNugetLocation\Microsoft.icu.icu4c.win.nuspec -BasePath $outputNugetLocation -OutputDirectory $output")
 Write-Host 'Executing: ' $nugetCmd
 &cmd /c $nugetCmd


### PR DESCRIPTION
## Summary
This PR adds a code signing config for ARM64 and changes the naming of the Nuget slightly.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

