### PR TITLE
Statically link the VCRuntime, VCStartup, and STL, but dynamically link to the UCRT.

### DIFF
--- a/icu-patches/patches/012-MSFT-Patch-StaticLink_VCRuntime_VCStartup_STL_but_DynamicLink_UCRT.patch
+++ b/icu-patches/patches/012-MSFT-Patch-StaticLink_VCRuntime_VCStartup_STL_but_DynamicLink_UCRT.patch
@@ -1,0 +1,94 @@
+From 136882f3f9ddd2d70342faf23fec2d7cd7855112 Mon Sep 17 00:00:00 2001
+From: Jeff Genovy <29107334+jefgen@users.noreply.github.com>
+Date: Sun, 26 Jul 2020 22:29:48 -0700
+Subject: [PATCH] Static link the VCRUNTIME, VCSTARTUP, and STL, but dynamic
+ link to the UCRT.
+
+---
+ icu/icu4c/source/common/common.vcxproj | 12 ++++++++++--
+ icu/icu4c/source/i18n/i18n.vcxproj     | 12 ++++++++++--
+ 2 files changed, 20 insertions(+), 4 deletions(-)
+
+diff --git a/icu/icu4c/source/common/common.vcxproj b/icu/icu4c/source/common/common.vcxproj
+index 3cee657..5d9e70a 100644
+--- a/icu/icu4c/source/common/common.vcxproj
++++ b/icu/icu4c/source/common/common.vcxproj
+@@ -71,24 +71,32 @@
+     <ClCompile>
+       <PreprocessorDefinitions>RBBI_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <BrowseInformation>true</BrowseInformation>
+-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
++      <!-- Static link the VCRUNTIME, VCSTARTUP and STL, but dynamic link to the UCRT. -->
++      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <OutputFile>..\..\$(IcuBinOutputDir)\icuuc67d.dll</OutputFile>
+       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuucd.pdb</ProgramDatabaseFile>
+       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuucd.lib</ImportLibrary>
++      <!-- This forces dynamic linking of the UCRT. -->
++      <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>
++      <AdditionalOptions>/DEFAULTLIB:ucrtd.lib %(AdditionalOptions)</AdditionalOptions>
+     </Link>
+   </ItemDefinitionGroup>
+   <!-- Options that are common to all 'Release' project configurations -->
+   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+     <ClCompile>
+-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
++      <!-- Static link the VCRUNTIME, VCSTARTUP and STL, but dynamic link to the UCRT. -->
++      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+     </ClCompile>
+     <Link>
+       <OutputFile>..\..\$(IcuBinOutputDir)\icuuc67.dll</OutputFile>
+       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuuc.pdb</ProgramDatabaseFile>
+       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuuc.lib</ImportLibrary>
++      <!-- This forces dynamic linking of the UCRT. -->
++      <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>
++      <AdditionalOptions>/DEFAULTLIB:ucrt.lib %(AdditionalOptions)</AdditionalOptions>
+     </Link>
+   </ItemDefinitionGroup>
+   <ItemGroup>
+diff --git a/icu/icu4c/source/i18n/i18n.vcxproj b/icu/icu4c/source/i18n/i18n.vcxproj
+index e009e21..b6e539f 100644
+--- a/icu/icu4c/source/i18n/i18n.vcxproj
++++ b/icu/icu4c/source/i18n/i18n.vcxproj
+@@ -72,19 +72,24 @@
+   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+     <ClCompile>
+       <BrowseInformation>true</BrowseInformation>
+-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
++      <!-- Static link the VCRUNTIME, VCSTARTUP and STL, but dynamic link to the UCRT. -->
++      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <AdditionalDependencies>icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+       <OutputFile>..\..\$(IcuBinOutputDir)\icuin67d.dll</OutputFile>
+       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuind.pdb</ProgramDatabaseFile>
+       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuind.lib</ImportLibrary>
++      <!-- This forces dynamic linking of the UCRT. -->
++      <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>
++      <AdditionalOptions>/DEFAULTLIB:ucrtd.lib %(AdditionalOptions)</AdditionalOptions>
+     </Link>
+   </ItemDefinitionGroup>
+   <!-- Options that are common to all 'Release' project configurations -->
+   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+     <ClCompile>
+-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
++      <!-- Static link the VCRUNTIME, VCSTARTUP and STL, but dynamic link to the UCRT. -->
++      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+     </ClCompile>
+     <Link>
+@@ -92,6 +97,9 @@
+       <OutputFile>..\..\$(IcuBinOutputDir)\icuin67.dll</OutputFile>
+       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuin.pdb</ProgramDatabaseFile>
+       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuin.lib</ImportLibrary>
++      <!-- This forces dynamic linking of the UCRT. -->
++      <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>
++      <AdditionalOptions>/DEFAULTLIB:ucrt.lib %(AdditionalOptions)</AdditionalOptions>
+     </Link>
+   </ItemDefinitionGroup>
+   <ItemGroup>
+-- 
+2.19.2
+

--- a/icu-patches/readme.md
+++ b/icu-patches/readme.md
@@ -4,14 +4,14 @@ This folder contains patches that are applied on top of the released version of 
 
 ## Approach
 
-Every patch is a maintenance burden. We strive to keep the patch count to a minimum. To that end, every patch should
-describe its reason for existence in its commit message.
+Every patch should be thought of as a maintenance burden. We generally want to keep the patch count to a minimum. To that end, every patch should describe its reason for existence.
 
-If an issue is already fixed upstream and we would obtain the fix simply by upgrading to a newer version of the library, then a patch file would, generally speaking, not be generated/created.
+If an issue has already been fixed upstream and we would obtain the fix by upgrading to a newer version of the library, then a patch file would (generally speaking), not be created, and the
+change from upstream would be cherry-picked as-is.
 
-Most of the patches are minor changes that are made in order to remove private, internal, or otherwise unwanted APIs from the SDK headers for the Windows OS version of ICU. (This version only exposes the public, stable, flat C API surface).
+The intent is to only keep patch files for things that will need to be continuously patched, even on newer versions. In other words, the patch files should be for changes that will be re-applied on every version update.
 
-The intent is to only keep patch files for things that will need to continuously be patched even on newer versions.
+Many of the patches are changes to remove private, internal, or otherwise unwanted APIs from the SDK headers for the Windows OS version of ICU. (The Windows OS version only exposes the public, stable, flat C API surface).
 
 *Any changes should be pursued upstream whenever possible.*
 

--- a/icu/icu4c/source/common/common.vcxproj
+++ b/icu/icu4c/source/common/common.vcxproj
@@ -71,24 +71,32 @@
     <ClCompile>
       <PreprocessorDefinitions>RBBI_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BrowseInformation>true</BrowseInformation>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <!-- Static link the VCRUNTIME, VCSTARTUP and STL, but dynamic link to the UCRT. -->
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <OutputFile>..\..\$(IcuBinOutputDir)\icuuc67d.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuucd.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuucd.lib</ImportLibrary>
+      <!-- This forces dynamic linking of the UCRT. -->
+      <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>
+      <AdditionalOptions>/DEFAULTLIB:ucrtd.lib %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <!-- Options that are common to all 'Release' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <!-- Static link the VCRUNTIME, VCSTARTUP and STL, but dynamic link to the UCRT. -->
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
     </ClCompile>
     <Link>
       <OutputFile>..\..\$(IcuBinOutputDir)\icuuc67.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuuc.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuuc.lib</ImportLibrary>
+      <!-- This forces dynamic linking of the UCRT. -->
+      <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>
+      <AdditionalOptions>/DEFAULTLIB:ucrt.lib %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/icu/icu4c/source/i18n/i18n.vcxproj
+++ b/icu/icu4c/source/i18n/i18n.vcxproj
@@ -72,19 +72,24 @@
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <BrowseInformation>true</BrowseInformation>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <!-- Static link the VCRUNTIME, VCSTARTUP and STL, but dynamic link to the UCRT. -->
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalDependencies>icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>..\..\$(IcuBinOutputDir)\icuin67d.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuind.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuind.lib</ImportLibrary>
+      <!-- This forces dynamic linking of the UCRT. -->
+      <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>
+      <AdditionalOptions>/DEFAULTLIB:ucrtd.lib %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <!-- Options that are common to all 'Release' project configurations -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <!-- Static link the VCRUNTIME, VCSTARTUP and STL, but dynamic link to the UCRT. -->
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
     </ClCompile>
     <Link>
@@ -92,6 +97,9 @@
       <OutputFile>..\..\$(IcuBinOutputDir)\icuin67.dll</OutputFile>
       <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuin.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuin.lib</ImportLibrary>
+      <!-- This forces dynamic linking of the UCRT. -->
+      <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>
+      <AdditionalOptions>/DEFAULTLIB:ucrt.lib %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

This PR modifies the vcxproj files for the "common" (uc) and "i18n" (in) libraries in order to statically link the VCRuntime (`libvcruntime.lib`), VCStartup (`libcmt.lib`), and STL/MSVCP (`libcpmt.lib`), but dynamically link the UCRT (`ucrt.lib`).

This PR also adds a new MSFT-Patch file to the `icu-patches` folder in order to retain this change for future versions of ICU. (I also reworded the `readme.md` file a bit for the patches folder).

The UCRT (`ucrtbase.dll`) is included as Windows OS component in Windows 10 and above. (See https://docs.microsoft.com/cpp/c-runtime-library/crt-library-features). On previous versions of Windows it is available via a Windows Update package. (See the KB article here: https://support.microsoft.com/kb/2999226).

However, the `vcruntime*.dll` and `msvcp*.dll` files are only available via the [Visual C++ Redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) (VC Redist), and the Redist must be installed manually.

This change avoids the need to install the VC Redist on Windows 10 (and previous Windows versions with the KB update) in order to use the `icuuc*.dll` and `icuin*.dll` libraries.

[cc/FYI: @tarekgh ]

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
