### PR TITLE
Update changelog for Taiwan calendar changes, and bump version to 67.1.0.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## ICU 67.1.0.2
+
+Data changes:
+- Microsoft data changes for the Taiwan calendar. [#8](https://github.com/microsoft/icu/pull/8).
+
 ## ICU 67.1.0.1
 
 Changes/modifications compared to the upstream `maint/maint-67` branch.

--- a/version.txt
+++ b/version.txt
@@ -32,5 +32,5 @@
 # maint/maint-* branch needs to be cherry-picked into this repo.
 #
 
-ICU_version = 67.1.0.1
+ICU_version = 67.1.0.2
 ICU_upstream_hash = 125e29d54990e74845e1546851b5afa3efab06ce


### PR DESCRIPTION
## Summary
This is related to PR #8.

This PR updates the `changelog.md` file for the Taiwan calendar changes, and bumps the MS-ICU version number to `67.1.0.2`, in order to prepare for a new release.

Note: Once this PR is merged I'll need to use a merge commit to merge this change to the `maint/maint-67` branch, as the changes for PR #8 were accidentally merged using a merge commit instead of a squash commit -- meaning that it can't be cleanly cherry-picked into the maint branch.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
