### PR TITLE
Update the changelog and bump the version number for the Taiwan calendar on v64

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## ICU 64.2.0.2
+
+Data changes:
+- Microsoft data changes for the Taiwan calendar. [#13](https://github.com/microsoft/icu/pull/13).
+
 ## ICU 64.2.0.1
 
 Changes/modifications compared to the upstream `maint/maint-64` branch.

--- a/version.txt
+++ b/version.txt
@@ -32,5 +32,5 @@
 # maint/maint-* branch needs to be cherry-picked into this repo.
 #
 
-ICU_version = 64.2.0.1
+ICU_version = 64.2.0.2
 ICU_upstream_hash = d4cb28ce9ceda0c8e7656be4d51e0b0d95685fd1


### PR DESCRIPTION
<!--
Thanks for creating a pull request! We appreciate you taking the time to contribute!

Please note that this is a fork of ICU that contains changes for the following:
- Maintenance related changes.
- Changes that are required for usage internal to Microsoft.
- Changes that are needed for the Windows OS build of ICU.
- Changes to address the set of locales provided by Windows NLS compared to ICU.

Before creating any pull request, please ensure that your change is related to one of the above reasons.

Most other changes, bug fixes, improvements, enhancements, etc. should be made in the upstream project here:
https://github.com/unicode-org/icu

-->

<!-- Enter a brief description/summary of your PR here. What does it fix, what does it change, how was it tested... -->
## Summary

This is related to PR #13 

This PR updates the changelog.md file for the Taiwan calendar changes, and bumps the MS-ICU version number to 64.2.0.2


Closing this PR due to being a duplicate of #14 
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [ ] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description
