### PR TITLE
Fix setting the MS-ICU version number in the uvernum.h file, and don't set it at build time.

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -9,6 +9,12 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 1
+    - task: PowerShell@2
+      displayName: 'Set ICU Version'
+      inputs:
+        targetType: filePath
+        filePath: './build/scripts/Set-ICUVersion.ps1'
+        arguments: '-icuVersionFile "$(BUILD.SOURCESDIRECTORY)\version.txt"'
     - script: |
         cd icu/icu4c/source && ./runConfigureICU Linux --disable-layout --disable-layoutex && make -j2 check
       displayName: 'Build and Test'
@@ -42,6 +48,12 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 1
+    - task: PowerShell@2
+      displayName: 'Set ICU Version'
+      inputs:
+        targetType: filePath
+        filePath: './build/scripts/Set-ICUVersion.ps1'
+        arguments: '-icuVersionFile "$(BUILD.SOURCESDIRECTORY)\version.txt"'
     - script: |
         export CPPFLAGS="-Werror -Wall -Wextra -Wextra-semi -Wundef -Wnon-virtual-dtor" && cd icu/icu4c/source && ./runConfigureICU Linux && make -j2 tests
       displayName: 'Build only (WarningsAsErrors)'
@@ -59,6 +71,12 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 1
+    - task: PowerShell@2
+      displayName: 'Set ICU Version'
+      inputs:
+        targetType: filePath
+        filePath: './build/scripts/Set-ICUVersion.ps1'
+        arguments: '-icuVersionFile "$(BUILD.SOURCESDIRECTORY)\version.txt"'
     - script: |
         cd icu/icu4c/source && \
         ICU_DATA_FILTER_FILE=../../../build/filters/test-data-filter.json ./runConfigureICU Linux && \
@@ -80,6 +98,12 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 1
+    - task: PowerShell@2
+      displayName: 'Set ICU Version'
+      inputs:
+        targetType: filePath
+        filePath: './build/scripts/Set-ICUVersion.ps1'
+        arguments: '-icuVersionFile "$(BUILD.SOURCESDIRECTORY)\version.txt"'
     - script: |
         export CXXFLAGS="-std=c++14 -Winvalid-constexpr" && cd icu/icu4c/source && ./runConfigureICU --enable-debug --disable-release Linux --disable-layout --disable-layoutex && make -j2 check
       displayName: 'Build and Test C++14'
@@ -101,6 +125,12 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 1
+    - task: PowerShell@2
+      displayName: 'Set ICU Version'
+      inputs:
+        targetType: filePath
+        filePath: './build/scripts/Set-ICUVersion.ps1'
+        arguments: '-icuVersionFile "$(BUILD.SOURCESDIRECTORY)\version.txt"'
     - task: VSBuild@1
       displayName: 'Build Solution'
       inputs:
@@ -139,6 +169,12 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 1
+    - task: PowerShell@2
+      displayName: 'Set ICU Version'
+      inputs:
+        targetType: filePath
+        filePath: './build/scripts/Set-ICUVersion.ps1'
+        arguments: '-icuVersionFile "$(BUILD.SOURCESDIRECTORY)\version.txt"'
     - task: VSBuild@1
       displayName: 'Build Solution'
       inputs:
@@ -172,6 +208,12 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 1
+    - task: PowerShell@2
+      displayName: 'Set ICU Version'
+      inputs:
+        targetType: filePath
+        filePath: './build/scripts/Set-ICUVersion.ps1'
+        arguments: '-icuVersionFile "$(BUILD.SOURCESDIRECTORY)\version.txt"'
     - task: VSBuild@1
       displayName: 'Build Solution'
       inputs:
@@ -217,6 +259,12 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 1
+    - task: PowerShell@2
+      displayName: 'Set ICU Version'
+      inputs:
+        targetType: filePath
+        filePath: './build/scripts/Set-ICUVersion.ps1'
+        arguments: '-icuVersionFile "$(BUILD.SOURCESDIRECTORY)\version.txt"'
     - powershell: |
         $filterPath = $Env:BUILD_SOURCESDIRECTORY + "\build\filters\test-data-filter.json"
         $vstsCommandString = "vso[task.setvariable variable=ICU_DATA_FILTER_FILE]" + $filterPath
@@ -243,6 +291,12 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 1
+    - task: PowerShell@2
+      displayName: 'Set ICU Version'
+      inputs:
+        targetType: filePath
+        filePath: './build/scripts/Set-ICUVersion.ps1'
+        arguments: '-icuVersionFile "$(BUILD.SOURCESDIRECTORY)\version.txt"'
     - task: VSBuild@1
       displayName: 'Build Solution'
       inputs:
@@ -267,6 +321,12 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 1
+    - task: PowerShell@2
+      displayName: 'Set ICU Version'
+      inputs:
+        targetType: filePath
+        filePath: './build/scripts/Set-ICUVersion.ps1'
+        arguments: '-icuVersionFile "$(BUILD.SOURCESDIRECTORY)\version.txt"'
     - script: |
        choco install -y msys2
        rem refreshenv

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -3,6 +3,8 @@ jobs:
 - job: ICU4C_MakeDist_Clang_Ubuntu_1804
   displayName: 'C: MakeDist Linux Clang (Ubuntu 18.04)'
   timeoutInMinutes: 30
+  workspace:
+      clean: all
   pool:
     vmImage: 'ubuntu-18.04'
   steps:
@@ -42,6 +44,8 @@ jobs:
 - job: ICU4C_Clang_Ubuntu_1604_WarningsAsErrors
   displayName: 'C: Linux Clang WarningsAsErrors (Ubuntu 16.04)'
   timeoutInMinutes: 30
+  workspace:
+      clean: all
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
@@ -65,6 +69,8 @@ jobs:
 - job: ICU4C_Clang_Ubuntu_TestDataFilter_1604
   displayName: 'C: Linux Clang TestDataFilter (Ubuntu 16.04)'
   timeoutInMinutes: 30
+  workspace:
+      clean: all
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
@@ -92,6 +98,8 @@ jobs:
 - job: ICU4C_Clang_Cpp14_Debug_Ubuntu_1804
   displayName: 'C: Linux Clang C++14 Debug (Ubuntu 18.04)'
   timeoutInMinutes: 30
+  workspace:
+      clean: all
   pool:
     vmImage: 'ubuntu-18.04'
   steps:
@@ -115,6 +123,8 @@ jobs:
 - job: ICU4C_MSVC_x64_Release_Distrelease
   displayName: 'C: MSVC 64-bit Release (VS 2017) + Distrelease'
   timeoutInMinutes: 30
+  workspace:
+      clean: all
   pool:
     vmImage: 'vs2017-win2016'
     demands: 
@@ -159,6 +169,8 @@ jobs:
 - job: ICU4C_MSVC_x86_Release_Distrelease
   displayName: 'C: MSVC 32-bit Release (VS 2017) + Distrelease'
   timeoutInMinutes: 30
+  workspace:
+      clean: all
   pool:
     vmImage: 'vs2017-win2016'
     demands: 
@@ -198,6 +210,8 @@ jobs:
 - job: ICU4C_MSVC_x64_ARM32_ARM64_Release_Distrelease
   displayName: 'C: MSVC x64 ARM32 ARM64 Release (VS 2017) + Distrelease ARM64'
   timeoutInMinutes: 60
+  workspace:
+      clean: all
   pool:
     vmImage: 'vs2017-win2016'
     demands: 
@@ -249,6 +263,8 @@ jobs:
 - job: ICU4C_MSVC_x64_Release_TestDataFilter
   displayName: 'C: MSVC 64-bit Release TestDataFilter (VS 2017)'
   timeoutInMinutes: 30
+  workspace:
+      clean: all
   pool:
     vmImage: 'vs2017-win2016'
     demands: 
@@ -281,6 +297,8 @@ jobs:
 - job: ICU4C_MSVC_x86_Debug
   displayName: 'C: MSVC 32-bit Debug (VS 2017)'
   timeoutInMinutes: 60
+  workspace:
+      clean: all
   pool:
     vmImage: 'vs2017-win2016'
     demands: 
@@ -313,6 +331,8 @@ jobs:
 - job: ICU4C_MSYS2_GCC_x86_64_Release
   displayName: 'C: MSYS2 GCC x86_64 Release'
   timeoutInMinutes: 45
+  workspace:
+      clean: all
   pool:
     vmImage: 'vs2017-win2016'
     demands:
@@ -355,6 +375,8 @@ jobs:
 - job: ICU4C_Clang_MacOSX_WarningsAsErrors
   displayName: 'C: macOSX Clang WarningsAsErrors (Mojave 10.14)'
   timeoutInMinutes: 30
+  workspace:
+      clean: all
   pool:
     vmImage: 'macOS-10.14'
   steps:

--- a/build/scripts/Set-ICUVersion.ps1
+++ b/build/scripts/Set-ICUVersion.ps1
@@ -42,13 +42,18 @@ foreach ($versionPart in $icuVersionArray) {
     }
 }
 
-# Edit the source file uvernum.h to set the macros U_ICU_VERSION and U_ICU_VERSION_BUILDLEVEL_NUM.
-# based on the values in the version.txt file.
+# Check that the values in the source file uvernum.h match the values in the version.txt file.
 $icuVersionHeader = (Get-Content "$PSScriptRoot\..\..\icu\icu4c\source\common\unicode\uvernum.h")
 $versionNumberDefine = '#define U_ICU_VERSION "'+ $ICUVersion +'"'
-$icuVersionHeader = $icuVersionHeader -replace('#define U_ICU_VERSION "[0-9\.]+"', $versionNumberDefine)
-$icuVersionHeader = $icuVersionHeader.replace('#define U_ICU_VERSION_BUILDLEVEL_NUM 0', '#define U_ICU_VERSION_BUILDLEVEL_NUM ' + $icuVersionArray[3])
-$icuVersionHeader | Set-Content "$PSScriptRoot\..\..\icu\icu4c\source\common\unicode\uvernum.h"
+if (!$icuVersionHeader -match $versionNumberDefine) {
+    Write-Host "Error: The ICU Version number in uvernum.h does not match the value in the version.txt file".
+    throw "Error: ICU Version number mismatch!"
+}
+$buildVersionNumberDefine = '#define U_ICU_VERSION_BUILDLEVEL_NUM '+ $icuVersionArray[3]
+if (!$icuVersionHeader -match $buildVersionNumberDefine) {
+    Write-Host "Error: The ICU Build Version number in uvernum.h does not match the value in the version.txt file".
+    throw "Error: ICU Version number mismatch!"
+}
 
 # Set the environment variable for the Nuget package to be the same as the ICU version (ex: 64.2.0.1)
 Write-Host 'Nuget Version = ' $ICUVersion

--- a/build/scripts/Set-ICUVersion.ps1
+++ b/build/scripts/Set-ICUVersion.ps1
@@ -45,12 +45,12 @@ foreach ($versionPart in $icuVersionArray) {
 # Check that the values in the source file uvernum.h match the values in the version.txt file.
 $icuVersionHeader = (Get-Content "$PSScriptRoot\..\..\icu\icu4c\source\common\unicode\uvernum.h")
 $versionNumberDefine = '#define U_ICU_VERSION "'+ $ICUVersion +'"'
-if (!$icuVersionHeader -match $versionNumberDefine) {
+if (!($icuVersionHeader -match $versionNumberDefine)) {
     Write-Host "Error: The ICU Version number in uvernum.h does not match the value in the version.txt file".
     throw "Error: ICU Version number mismatch!"
 }
 $buildVersionNumberDefine = '#define U_ICU_VERSION_BUILDLEVEL_NUM '+ $icuVersionArray[3]
-if (!$icuVersionHeader -match $buildVersionNumberDefine) {
+if ((!$icuVersionHeader -match $buildVersionNumberDefine)) {
     Write-Host "Error: The ICU Build Version number in uvernum.h does not match the value in the version.txt file".
     throw "Error: ICU Version number mismatch!"
 }

--- a/build/scripts/Set-ICUVersion.ps1
+++ b/build/scripts/Set-ICUVersion.ps1
@@ -50,7 +50,7 @@ if (!($icuVersionHeader -match $versionNumberDefine)) {
     throw "Error: ICU Version number mismatch!"
 }
 $buildVersionNumberDefine = '#define U_ICU_VERSION_BUILDLEVEL_NUM '+ $icuVersionArray[3]
-if ((!$icuVersionHeader -match $buildVersionNumberDefine)) {
+if (!($icuVersionHeader -match $buildVersionNumberDefine)) {
     Write-Host "Error: The ICU Build Version number in uvernum.h does not match the value in the version.txt file".
     throw "Error: ICU Version number mismatch!"
 }

--- a/icu/icu4c/source/common/unicode/uvernum.h
+++ b/icu/icu4c/source/common/unicode/uvernum.h
@@ -79,7 +79,7 @@
  *  @stable ICU 4.0
  */
 #ifndef U_ICU_VERSION_BUILDLEVEL_NUM
-#define U_ICU_VERSION_BUILDLEVEL_NUM 0
+#define U_ICU_VERSION_BUILDLEVEL_NUM 2
 #endif
 
 /** Glued version suffix for renamers
@@ -139,7 +139,7 @@
  *  This value will change in the subsequent releases of ICU
  *  @stable ICU 2.4
  */
-#define U_ICU_VERSION "67.1"
+#define U_ICU_VERSION "67.1.0.2"
 
 /**
  * The current ICU library major version number as a string, for library name suffixes.

--- a/version.txt
+++ b/version.txt
@@ -31,6 +31,9 @@
 # This makes it easier to tell if a post-release fix in the upstream
 # maint/maint-* branch needs to be cherry-picked into this repo.
 #
+# Note: The version number needs to be kept in sync with the value
+# in the header file "uvernum.h" whenever updated and/or changed.
+#
 
 ICU_version = 67.1.0.2
 ICU_upstream_hash = 125e29d54990e74845e1546851b5afa3efab06ce


### PR DESCRIPTION
## Summary
When testing out the Nuget package, @safern noticed that the value reported by the API `u_getVersion` doesn't actually match the MS-ICU version number. This is because the macro `U_ICU_VERSION` wasn't updated, only the macro `U_ICU_VERSION_BUILDLEVEL_NUM` was being updated. (Thanks @safern!)

I was going to modify the `Set-ICUVersion.ps1` script to set this macro as well at build time.

However, when testing I noticed that the `make dist` command actually takes the output from the git commit using the `git archive` command. This means that we need to actually modify and commit the version number, and not set it on the fly during the build.

Instead, we'll now have to update the two macros in the `uvernum.h` file directly, but in order to make sure things don't get out of sync, I modified the `Set-ICUVersion.ps1` script to check that they match.

Also in this change:
I added a "clean" step to the CI pipeline to clean everything, as I noticed that if you do a force push, sometimes the contents of the build machines doesn't get cleaned properly.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
