### PR TITLE
Produce Nuget Symbol Packages for debugging, and add some more diagnostics to pipeline

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -21,6 +21,8 @@ stages:
       demands:
       - msbuild
       - visualstudio
+    workspace:
+      clean: all
 
     # Note: The VS uses "Win32" for 32-bit arch, but we use x86 in the pipeline.
     # This matrix strategy lets us build the different architectures in parallel.
@@ -79,6 +81,7 @@ stages:
         platform: '$(IcuBuildPlatform)'
         configuration: Release
 
+    # Binaries (DLLs)
     - task: CopyFiles@2
       displayName: 'Copy x64'
       inputs:
@@ -112,7 +115,7 @@ stages:
         flattenFolders: true
       condition: eq(variables['BuildPlatform'],'x86')
 
-    # This is a sanity check to ensure that we have the real data DLL and not the stubdata DLL.
+    # This is a sanity check to ensure that we have the real data DLL, and not the stubdata DLL.
     - powershell: |
         Write-Host 'Checking the size of the ICU data DLL...'
         if ((Get-Item "$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\icudt*.dll").length -lt 5KB) {
@@ -126,6 +129,46 @@ stages:
         PathtoPublish: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)'
         ArtifactName: '$(PublishBinariesName)'
 
+    # Symbols (PDBs)
+    - task: CopyFiles@2
+      displayName: 'Copy symbols x64'
+      inputs:
+        Contents: |
+          icu\icu4c\lib64\icuuc*.pdb
+          icu\icu4c\lib64\icuin*.pdb
+          icu\icu4c\lib64\icudt*.pdb
+        TargetFolder: '$(Build.ArtifactStagingDirectory)\symbols-$(BuildPlatform)'
+        flattenFolders: true
+      condition: eq(variables['BuildPlatform'],'x64')
+
+    - task: CopyFiles@2
+      displayName: 'Copy symbols ARM64'
+      inputs:
+        Contents: |
+          icu\icu4c\libARM64\icuuc*.pdb
+          icu\icu4c\libARM64\icuin*.pdb
+          icu\icu4c\libARM64\icudt*.pdb
+        TargetFolder: '$(Build.ArtifactStagingDirectory)\symbols-$(BuildPlatform)'
+        flattenFolders: true
+      condition: eq(variables['BuildPlatform'],'ARM64')
+
+    - task: CopyFiles@2
+      displayName: 'Copy symbols x86'
+      inputs:
+        Contents: |
+          icu\icu4c\lib\icuuc*.pdb
+          icu\icu4c\lib\icuin*.pdb
+          icu\icu4c\lib\icudt*.pdb
+        TargetFolder: '$(Build.ArtifactStagingDirectory)\symbols-$(BuildPlatform)'
+        flattenFolders: true
+      condition: eq(variables['BuildPlatform'],'x86')
+
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish: symbols'
+      inputs:
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)\symbols-$(BuildPlatform)'
+        ArtifactName: 'symbols-win-$(BuildPlatform)'
+
 - stage: CodeSignBinaries
   condition: and(succeeded(), eq(variables.codeSign, true))
   dependsOn: Build
@@ -133,8 +176,10 @@ stages:
     name: Package ES CodeHub Lab E
   jobs:
   - job: CodeSignBits
+    workspace:
+      clean: all
     
-    # This matrix strategy lets us sign the architectures in parallel.
+    # This matrix strategy lets us code-sign the architectures in parallel.
     strategy:
       matrix:
         Win32:
@@ -210,6 +255,8 @@ stages:
 
   jobs:
   - job: CreateNugetAndCodeSign
+    workspace:
+      clean: all
     steps:
     - checkout: self
       lfs: true
@@ -239,6 +286,7 @@ stages:
         Tree /F /A $(BUILD.BINARIESDIRECTORY)
       displayName: 'DIAG: dir'
 
+    # Binaries (DLLs)
     - task: DownloadBuildArtifacts@0
       displayName: 'Download win-x86'
       inputs:
@@ -257,6 +305,25 @@ stages:
         artifactName: 'win-ARM64'
         downloadPath: '$(Build.BINARIESDIRECTORY)\bits'
 
+    # Symbols (PDBs)
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download symbols-win-x86'
+      inputs:
+        artifactName: 'symbols-win-x86'
+        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
+
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download symbols-win-x64'
+      inputs:
+        artifactName: 'symbols-win-x64'
+        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
+
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download symbols-win-ARM64'
+      inputs:
+        artifactName: 'symbols-win-ARM64'
+        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
+
     - powershell: |
         Write-Host ""
         Write-Host "$(BUILD.BINARIESDIRECTORY)"
@@ -271,7 +338,7 @@ stages:
       inputs:
         targetType: filePath
         filePath: './build/scripts/Create-Nuget-Runtime.ps1'
-        arguments: '-sourceRoot $(BUILD.SOURCESDIRECTORY) -icuBinaries "$(BUILD.BINARIESDIRECTORY)\bits" -output $(BUILD.ArtifactStagingDirectory)\output -codesign $(codeSign)'
+        arguments: '-sourceRoot $(BUILD.SOURCESDIRECTORY) -icuBinaries "$(BUILD.BINARIESDIRECTORY)\bits" -icuSymbols "$(BUILD.BINARIESDIRECTORY)\symbols" -output $(BUILD.ArtifactStagingDirectory)\output -codesign $(codeSign)'
 
     - powershell: |
         Write-Host ""
@@ -279,7 +346,7 @@ stages:
         Tree /F /A $(BUILD.ArtifactStagingDirectory)
       displayName: 'DIAG: dir'
 
-    # This "work-around" is unfortunately needed as the pipeline runs on x64/x86, but Nuget meta-packages are architecture neutral (AnyCPU).
+    # This "work-around" is needed since the pipeline runs on x64/x86, but Nuget meta-packages are architecture neutral.
     - powershell: |
         Write-Host "Change to AnyCPU"
         Write-Host "##vso[task.setvariable variable=BuildPlatform]AnyCPU"
@@ -297,12 +364,20 @@ stages:
         outPathRoot: '$(BUILD.ArtifactStagingDirectory)\output\package'
       condition: and(succeeded(), eq(variables.codeSign, true))
 
-    # This checks that all the Nuget packages are code-signed.
+    # This checks that all the Nuget packages are signed.
     - powershell: |
         $cmd = ('nuget verify -signature -CertificateFingerprint 3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE ' + $env:Build_ArtifactStagingDirectory + "\output\package\signed\*.nupkg")
         Write-Host "Executing: $cmd"
         &cmd /c $cmd
-      displayName: 'Verify Nuget Packages are Code-Signed'
+      displayName: 'Verify Nuget Packages are Signed'
+      condition: and(succeeded(), eq(variables.codeSign, true))
+
+    # Check that the Nuget Symbol packages are also signed.
+    - powershell: |
+        $cmd = ('nuget verify -signature -CertificateFingerprint 3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE ' + $env:Build_ArtifactStagingDirectory + "\output\package\signed\*.snupkg")
+        Write-Host "Executing: $cmd"
+        &cmd /c $cmd
+      displayName: 'Verify Nuget Symbol Packages are Signed'
       condition: and(succeeded(), eq(variables.codeSign, true))
 
     - task: PublishBuildArtifacts@1

--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -252,6 +252,8 @@ stages:
   condition: and(in(dependencies.Build.result, 'Succeeded'), in(dependencies.CodeSignBinaries.result, 'Succeeded', 'Skipped'))
   pool:
     name: Package ES CodeHub Lab E
+  variables:
+    BuildPlatform: AnyCPU
 
   jobs:
   - job: CreateNugetAndCodeSign
@@ -345,13 +347,6 @@ stages:
         Write-Host "$(BUILD.ArtifactStagingDirectory)"
         Tree /F /A $(BUILD.ArtifactStagingDirectory)
       displayName: 'DIAG: dir'
-
-    # This "work-around" is needed since the pipeline runs on x64/x86, but Nuget meta-packages are architecture neutral.
-    - powershell: |
-        Write-Host "Change to AnyCPU"
-        Write-Host "##vso[task.setvariable variable=BuildPlatform]AnyCPU"
-      displayName: 'Change BuildPlatform to AnyCPU for signing'
-      condition: and(succeeded(), eq(variables.codeSign, true))
 
     - task: PkgESCodeSign@10
       displayName: 'CodeSign MS-ICU Nuget'

--- a/build/nuget/SignConfig-ICU-Binaries-runtime.xml
+++ b/build/nuget/SignConfig-ICU-Binaries-runtime.xml
@@ -1,34 +1,28 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <SignConfigXML>
   <!-- Note: We use the AuthenticodeFormer cert as we have made modifcations to the code. -->
+  <!-- 
+    Names of the ICU library DLLs on Windows:
+      Data library:   icudt
+      Common library: icuuc
+      i18n library:   icuin
+  -->
   <job platform="x86" certSubject="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
     configuration="Release" dest="__OUTPATHROOT__\signed" jobname="Code Sign MS-ICU binaries (x86)" approvers="">
-    <!-- DLLs -->
-    <!-- Data library -->
     <file src="__INPATHROOT__\icudt*.dll" signType="AuthenticodeFormer" />
-    <!-- Common library -->
     <file src="__INPATHROOT__\icuuc*.dll" signType="AuthenticodeFormer" />
-    <!-- i18n library -->
     <file src="__INPATHROOT__\icuin*.dll" signType="AuthenticodeFormer" />
   </job>
   <job platform="x64" certSubject="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
     configuration="Release" dest="__OUTPATHROOT__\signed" jobname="Code Sign MS-ICU binaries (x64)" approvers="">
-    <!-- DLLs -->
-    <!-- Data library -->
     <file src="__INPATHROOT__\icudt*.dll" signType="AuthenticodeFormer" />
-    <!-- Common library -->
     <file src="__INPATHROOT__\icuuc*.dll" signType="AuthenticodeFormer" />
-    <!-- i18n library -->
     <file src="__INPATHROOT__\icuin*.dll" signType="AuthenticodeFormer" />
   </job>
   <job platform="ARM64" certSubject="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
     configuration="Release" dest="__OUTPATHROOT__\signed" jobname="Code Sign MS-ICU binaries (ARM64)" approvers="">
-    <!-- DLLs -->
-    <!-- Data library -->
     <file src="__INPATHROOT__\icudt*.dll" signType="AuthenticodeFormer" />
-    <!-- Common library -->
     <file src="__INPATHROOT__\icuuc*.dll" signType="AuthenticodeFormer" />
-    <!-- i18n library -->
     <file src="__INPATHROOT__\icuin*.dll" signType="AuthenticodeFormer" />
   </job>
 </SignConfigXML>

--- a/build/nuget/SignConfig-ICU-Nuget.xml
+++ b/build/nuget/SignConfig-ICU-Nuget.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <SignConfigXML>
-
   <job platform="AnyCPU" configuration="Release" certSubject="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
    dest="__OUTPATHROOT__\signed" jobname="Code Sign MS-ICU Nuget" approvers="">
+    <!-- Metapackage -->
     <file src="__INPATHROOT__\Microsoft.ICU.*.nupkg" signType="Nuget" />
+    <!-- Binary packages -->
     <file src="__INPATHROOT__\runtime.win-arm64.Microsoft.ICU.*.nupkg" signType="Nuget" />
     <file src="__INPATHROOT__\runtime.win-x64.Microsoft.ICU.*.nupkg" signType="Nuget" />
     <file src="__INPATHROOT__\runtime.win-x86.Microsoft.ICU.*.nupkg" signType="Nuget" />
+    <!-- Symbol packages -->
+    <file src="__INPATHROOT__\runtime.win-arm64.Microsoft.ICU.*.snupkg" signType="Nuget" />
+    <file src="__INPATHROOT__\runtime.win-x64.Microsoft.ICU.*.snupkg" signType="Nuget" />
+    <file src="__INPATHROOT__\runtime.win-x86.Microsoft.ICU.*.snupkg" signType="Nuget" />
   </job>
-  
 </SignConfigXML>

--- a/build/nuget/Template-runtime-meta.nuspec
+++ b/build/nuget/Template-runtime-meta.nuspec
@@ -7,6 +7,7 @@
     <license type="file">LICENSE</license>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectUrl>https://github.com/microsoft/icu</projectUrl>
+    <releaseNotes>https://aka.ms/ms-icu-nuget-release-notes</releaseNotes>
     <description>This package contains pre-built binaries of ICU4C using the Microsoft ICU (MS-ICU) repo on GitHub.
 
 ICU4C is a mature, widely used set of C/C++ libraries providing Unicode and Globalization support for software applications.
@@ -15,9 +16,8 @@ The MS-ICU repo contains a modified version of ICU4C with changes needed for con
 
 This runtime package only contains the common and i18n libraries, along with the data library.
 
-Note: In order to have binary compatibility between versions see: https://aka.ms/icu-binary-compatibility
+Note: For binary compatibility between versions see the page here: https://aka.ms/icu-binary-compatibility
     </description>
-    <releaseNotes>https://aka.ms/ms-icu-nuget-release-notes</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>native nativepackage icu icu4c</tags>
     <dependencies>

--- a/build/nuget/Template-runtime-rid.nuspec
+++ b/build/nuget/Template-runtime-rid.nuspec
@@ -7,10 +7,9 @@
     <license type="file">LICENSE</license>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectUrl>https://github.com/microsoft/icu</projectUrl>
-    <description>Internal implementation package not meant for direct consumption. Please do not reference directly.
-This package contains pre-built binaries of MS-ICU.
-When using NuGet 3.x this package requires at least version 3.4.</description>
     <releaseNotes>https://aka.ms/ms-icu-nuget-release-notes</releaseNotes>
+    <description>Internal implementation package not meant for direct consumption. Please do not reference directly.
+This package contains pre-built binaries of MS-ICU.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
   </metadata>
 </package>


### PR DESCRIPTION
## Summary
This change modifies the Nuget build pipeline to enable building Nuget Symbol packages for the Windows binaries.

These symbol packages (`*.snupkg`) contain the PDB files that are necessary for debugging. They are separate from the main package in order to reduce the size/bloat of the "runtime" package. Nuget.org has special support for resolving symbols by pulling these "symbol" packages, so this allows a clean separation between the DLLs and the PDBs. (Meaning you don't download the PDBs by default unless you need them).

This change also modifies the build pipeline to add more diagnostic output (which is useful for debugging build issues), and explicit "clean" steps to ensure that each stage doesn't have leftover artifacts from previous runs.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
