### PR TITLE
Bump the version number to 67.1.0.3, and update the changelog.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## ICU 67.1.0.3
+
+Code/general changes:
+- Enable building Nuget runtime package(s) for Windows containing pre-built binaries.
+- Statically link the VCRuntime, VCStartup, and STL, and dynamically link to the UCRT. [#10](https://github.com/microsoft/icu/pull/10)
+
+Data changes:
+- Fixes to the month names for the vai-Latn locale. [#19](https://github.com/microsoft/icu/pull/19).
+
 ## ICU 67.1.0.2
 
 Data changes:

--- a/icu/icu4c/source/common/unicode/uvernum.h
+++ b/icu/icu4c/source/common/unicode/uvernum.h
@@ -79,7 +79,7 @@
  *  @stable ICU 4.0
  */
 #ifndef U_ICU_VERSION_BUILDLEVEL_NUM
-#define U_ICU_VERSION_BUILDLEVEL_NUM 2
+#define U_ICU_VERSION_BUILDLEVEL_NUM 3
 #endif
 
 /** Glued version suffix for renamers
@@ -139,7 +139,7 @@
  *  This value will change in the subsequent releases of ICU
  *  @stable ICU 2.4
  */
-#define U_ICU_VERSION "67.1.0.2"
+#define U_ICU_VERSION "67.1.0.3"
 
 /**
  * The current ICU library major version number as a string, for library name suffixes.

--- a/version.txt
+++ b/version.txt
@@ -35,5 +35,5 @@
 # in the header file "uvernum.h" whenever updated and/or changed.
 #
 
-ICU_version = 67.1.0.2
+ICU_version = 67.1.0.3
 ICU_upstream_hash = 125e29d54990e74845e1546851b5afa3efab06ce


### PR DESCRIPTION
## Summary
This bumps the version number to 67.1.0.3, and updates the changelog.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
