### PR TITLE
Fix the naming of the dependent Runtime Nuget packages.

### DIFF
--- a/build/nuget/SignConfig-ICU-Nuget.xml
+++ b/build/nuget/SignConfig-ICU-Nuget.xml
@@ -3,14 +3,14 @@
   <job platform="AnyCPU" configuration="Release" certSubject="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
    dest="__OUTPATHROOT__\signed" jobname="Code Sign MS-ICU Nuget" approvers="">
     <!-- Metapackage -->
-    <file src="__INPATHROOT__\Microsoft.ICU.*.nupkg" signType="Nuget" />
+    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime*.nupkg" signType="Nuget" />
     <!-- Binary packages -->
-    <file src="__INPATHROOT__\runtime.win-arm64.Microsoft.ICU.*.nupkg" signType="Nuget" />
-    <file src="__INPATHROOT__\runtime.win-x64.Microsoft.ICU.*.nupkg" signType="Nuget" />
-    <file src="__INPATHROOT__\runtime.win-x86.Microsoft.ICU.*.nupkg" signType="Nuget" />
+    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x64*.nupkg" signType="Nuget" />
+    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x86*.nupkg" signType="Nuget" />
+    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-arm64*.nupkg" signType="Nuget" />
     <!-- Symbol packages -->
-    <file src="__INPATHROOT__\runtime.win-arm64.Microsoft.ICU.*.snupkg" signType="Nuget" />
-    <file src="__INPATHROOT__\runtime.win-x64.Microsoft.ICU.*.snupkg" signType="Nuget" />
-    <file src="__INPATHROOT__\runtime.win-x86.Microsoft.ICU.*.snupkg" signType="Nuget" />
+    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x64*.snupkg" signType="Nuget" />
+    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x86*.snupkg" signType="Nuget" />
+    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-arm64*.snupkg" signType="Nuget" />
   </job>
 </SignConfigXML>

--- a/build/scripts/Create-Nuget-Runtime.ps1
+++ b/build/scripts/Create-Nuget-Runtime.ps1
@@ -129,7 +129,7 @@ foreach ($rid in $runtimeIdentifiers)
     "commit = $localSHA" | Add-Content -Encoding UTF8 $versionTxtFile
 
     # Update the placeholders in the template nuspec file.
-    $runtimePackageId = "runtime.$rid.$packageName";
+    $runtimePackageId = "$packageName.$rid";
     $nuspecFileContent = (Get-Content "$sourceRoot\build\nuget\Template-runtime-rid.nuspec")
     $nuspecFileContent = $nuspecFileContent.replace('$runtimePackageId$', $runtimePackageId)
     $nuspecFileContent = $nuspecFileContent.replace('$version$', $packageVersion)
@@ -171,7 +171,7 @@ $ret = New-Item -ItemType File -Force -Path $versionTxtFile
 $deps = ""
 foreach ($rid in $runtimeIdentifiers)
 {
-    $deps = $deps + "      <dependency id=`"runtime.$rid.$packageName`" version=`"$packageVersion`" />`r`n"
+    $deps = $deps + "      <dependency id=`"$packageName.$rid`" version=`"$packageVersion`" />`r`n"
 }
 
 Write-Host "Adding these runtime packages as dependencies:"

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## ICU 67.1.0.4
+
+Code/general changes:
+- Fixes the name of the dependent runtime Nuget packages for Windows.
+
 ## ICU 67.1.0.3
 
 Code/general changes:

--- a/icu/icu4c/source/common/unicode/uvernum.h
+++ b/icu/icu4c/source/common/unicode/uvernum.h
@@ -79,7 +79,7 @@
  *  @stable ICU 4.0
  */
 #ifndef U_ICU_VERSION_BUILDLEVEL_NUM
-#define U_ICU_VERSION_BUILDLEVEL_NUM 3
+#define U_ICU_VERSION_BUILDLEVEL_NUM 4
 #endif
 
 /** Glued version suffix for renamers
@@ -139,7 +139,7 @@
  *  This value will change in the subsequent releases of ICU
  *  @stable ICU 2.4
  */
-#define U_ICU_VERSION "67.1.0.3"
+#define U_ICU_VERSION "67.1.0.4"
 
 /**
  * The current ICU library major version number as a string, for library name suffixes.

--- a/version.txt
+++ b/version.txt
@@ -35,5 +35,5 @@
 # in the header file "uvernum.h" whenever updated and/or changed.
 #
 
-ICU_version = 67.1.0.3
+ICU_version = 67.1.0.4
 ICU_upstream_hash = 125e29d54990e74845e1546851b5afa3efab06ce


### PR DESCRIPTION
## Summary
It turns out that Nuget.org won't accept any packages that start with a `runtime*` prefix. So we'll need to move the Runtime ID (RID) to the end of the Nuget package name for the dependent runtime packages instead.

This change also bumps the version number, as Nuget.org won't let you re-submit a package with the same version once it has been removed/deleted.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
