### PR TITLE
Enable building Linux x64 Nuget runtime package

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -14,7 +14,69 @@ variables:
 stages:
 - stage: Build
   jobs:
+  - job: BuildLinux
+    pool:
+      name: Azure Pipelines
+      vmImage: 'ubuntu-18.04'
+    workspace:
+      clean: all
+
+    # Note: We only have one distro for now, but this lets others be added more easily in the future.
+    strategy:
+      matrix:
+        centos:
+          distro: 'centos'
+
+    steps:
+      - checkout: self
+        lfs: true
+        fetchDepth: 1
+
+      - task: PowerShell@2
+        displayName: 'Set ICU Version'
+        inputs:
+          targetType: filePath
+          filePath: './build/scripts/Set-ICUVersion.ps1'
+          arguments: '-icuVersionFile "$(BUILD.SOURCESDIRECTORY)\version.txt"'
+
+      - task: Docker@2
+        displayName: 'Setup Docker Container: $(distro)'
+        inputs:
+          command: build
+          Dockerfile: 'build/dockerfiles/$(distro)/Dockerfile'
+          arguments: -t ms-icu-container
+
+      - script: |
+          mkdir /tmp/build-output && docker run --rm -v $(pwd):/src -v /tmp/build-output:/dist ms-icu-container /src/build/scripts/build-icu.sh
+        displayName: 'Build, test, and make install'
+
+      - script: |
+          cd /tmp/build-output && ls -Rl
+        displayName: 'DIAG: ls -Rl'
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifacts'
+        inputs:
+          PathtoPublish: '/tmp/build-output/icu-binaries.tar.gz'
+          ArtifactName: 'linux_$(distro).tar.gz'
+
+      # Note: We only copy the .so files with the full version (ex: libicuuc.so.67.1.0.4)
+      - script: |
+          mkdir /tmp/icu-binaries
+          ls -al /tmp/build-output/icu/usr/local/lib/
+          cp /tmp/build-output/icu/usr/local/lib/libicudata.so.$(ICUVersion) /tmp/icu-binaries
+          cp /tmp/build-output/icu/usr/local/lib/libicui18n.so.$(ICUVersion) /tmp/icu-binaries
+          cp /tmp/build-output/icu/usr/local/lib/libicuuc.so.$(ICUVersion) /tmp/icu-binaries
+        displayName: 'Copy .so files'
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish: binaries'
+        inputs:
+          PathtoPublish: '/tmp/icu-binaries'
+          ArtifactName: 'linux-x64'
+
   - job: BuildWindows
+    timeoutInMinutes: 30
     pool:
       name: Azure Pipelines
       vmImage: 'vs2017-win2016'
@@ -176,6 +238,7 @@ stages:
     name: Package ES CodeHub Lab E
   jobs:
   - job: CodeSignBits
+    timeoutInMinutes: 30
     workspace:
       clean: all
     
@@ -257,6 +320,7 @@ stages:
 
   jobs:
   - job: CreateNugetAndCodeSign
+    timeoutInMinutes: 30
     workspace:
       clean: all
     steps:
@@ -305,6 +369,12 @@ stages:
       displayName: 'Download win-ARM64'
       inputs:
         artifactName: 'win-ARM64'
+        downloadPath: '$(Build.BINARIESDIRECTORY)\bits'
+
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download linux-x64'
+      inputs:
+        artifactName: 'linux-x64'
         downloadPath: '$(Build.BINARIESDIRECTORY)\bits'
 
     # Symbols (PDBs)

--- a/build/dockerfiles/centos/Dockerfile
+++ b/build/dockerfiles/centos/Dockerfile
@@ -1,0 +1,19 @@
+# This uses the DotNet CentOS 7 docker image to build.
+# https://github.com/dotnet/dotnet-buildtools-prereqs-docker
+
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-359e48e-20200313130914
+MAINTAINER Jeff Genovy <29107334+jefgen@users.noreply.github.com>
+LABEL com.github.microsoft.icu="centos-7"
+
+# Remove icu-dev, so it doesn't conflict.
+RUN yum -y remove libicu-devel
+
+# When we run the docker container we will mount the source repo here
+VOLUME /src
+
+# The output from make install will go here
+VOLUME /dist
+
+# Do the actual build in tmp
+RUN mkdir /tmp/build
+WORKDIR /tmp/build

--- a/build/nuget/SignConfig-ICU-Nuget.xml
+++ b/build/nuget/SignConfig-ICU-Nuget.xml
@@ -8,6 +8,7 @@
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x64*.nupkg" signType="Nuget" />
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x86*.nupkg" signType="Nuget" />
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-arm64*.nupkg" signType="Nuget" />
+    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.linux-x64*.nupkg" signType="Nuget" />
     <!-- Symbol packages -->
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x64*.snupkg" signType="Nuget" />
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x86*.snupkg" signType="Nuget" />

--- a/build/scripts/build-icu.sh
+++ b/build/scripts/build-icu.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# echo commands when executing them
+set -x
+
+# Disable color output
+export TERM=xterm
+
+# Number of CPU Cores to use for make
+export CPUCORES=$(nproc)
+
+echo Building in: $(pwd)
+
+# Configure ICU for building. Skip layout[ex] and samples
+/src/icu/icu4c/source/runConfigureICU Linux --disable-layout --disable-layoutex --disable-samples || exit 1
+
+# Build, run the tests, then install into DESTDIR.
+make -j${CORES} check && make -j${CORES} DESTDIR=/dist/icu releaseDist || exit 1
+
+# Test that icuinfo works with the built libs in the installed location
+LD_LIBRARY_PATH=/dist/icu/usr/local/lib /dist/icu/usr/local/bin/icuinfo || exit 1
+
+# Copy OS Release (name of the distro) if it exists
+if [ -f /etc/os-release ];
+then
+    cat /etc/os-release
+    cp /etc/os-release /dist/icu
+fi
+
+# Copy the MS-ICU version number
+cp /src/version.txt /dist/icu
+
+# Pack up the binaries into a tarball
+cd /dist && tar -czpf icu-binaries.tar.gz -C /dist/icu .


### PR DESCRIPTION
## Summary
This change enables building Linux x64 runtime packages for the MS-ICU Nuget package in the build pipeline.

The binaries produced link to `glibc`, so they should work on any Linux distribution that uses the `glibc` standard library. (Note: This means that they won't work on distros like Alpine, which use `musl` as the standard library. Adding support for `musl` is out-of-scope for this PR).

In order to produce these binaries, we actually build inside a Docker container, and then extract the output from that, and then package it up in the Nuget package.
To do this we use the special CentOS7 Docker image to build, which is the same as the one used for dotnet. This image has a number of updates applied and tools preinstalled, and also uses a much newer version of the Clang compiler (Clang 9) by default 
According to the dotnet team, these docker images are very stable and retained indefinitely, so we shouldn't need to rev the container image very often.

Note: There's no symbols for this package yet, as I'm not sure how to produce symbols for *nix packages.
Additionally, the Nuget.org site doesn't seem to support uploading anything other than PDB files -- which aren't a thing for .so binaries. I'm omitting them for now, and we can investigate adding symbols later.

cc: @safern, @tarekgh 
(And thank you for all your help with this!)

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
