### PR TITLE
Bump the version number to 67.1.0.5, and update the changelog.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## ICU 67.1.0.5
+
+Code/general changes:
+- Enable building Linux x64 Nuget runtime package (for glibc based distros). [#27](https://github.com/microsoft/icu/pull/27)
+- Include the ICU major version number on PDB files (for common and i18n) to match the DLL filenames. [#26](https://github.com/microsoft/icu/pull/26)
+- Fix the build-time script Set-ICUVersion.ps1 to set the environment variable for the current session.
+
 ## ICU 67.1.0.4
 
 Code/general changes:

--- a/icu/icu4c/source/common/unicode/uvernum.h
+++ b/icu/icu4c/source/common/unicode/uvernum.h
@@ -79,7 +79,7 @@
  *  @stable ICU 4.0
  */
 #ifndef U_ICU_VERSION_BUILDLEVEL_NUM
-#define U_ICU_VERSION_BUILDLEVEL_NUM 4
+#define U_ICU_VERSION_BUILDLEVEL_NUM 5
 #endif
 
 /** Glued version suffix for renamers
@@ -139,7 +139,7 @@
  *  This value will change in the subsequent releases of ICU
  *  @stable ICU 2.4
  */
-#define U_ICU_VERSION "67.1.0.4"
+#define U_ICU_VERSION "67.1.0.5"
 
 /**
  * The current ICU library major version number as a string, for library name suffixes.

--- a/version.txt
+++ b/version.txt
@@ -35,5 +35,5 @@
 # in the header file "uvernum.h" whenever updated and/or changed.
 #
 
-ICU_version = 67.1.0.4
+ICU_version = 67.1.0.5
 ICU_upstream_hash = 125e29d54990e74845e1546851b5afa3efab06ce


### PR DESCRIPTION
## Summary
This change bumps the version number to 67.1.0.5, and updates the changelog to add notes about the included changes/fixes.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
