### PR TITLE
Update maint/maint-67 to 67.1.0.5

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -14,7 +14,69 @@ variables:
 stages:
 - stage: Build
   jobs:
+  - job: BuildLinux
+    pool:
+      name: Azure Pipelines
+      vmImage: 'ubuntu-18.04'
+    workspace:
+      clean: all
+
+    # Note: We only have one distro for now, but this lets others be added more easily in the future.
+    strategy:
+      matrix:
+        centos:
+          distro: 'centos'
+
+    steps:
+      - checkout: self
+        lfs: true
+        fetchDepth: 1
+
+      - task: PowerShell@2
+        displayName: 'Set ICU Version'
+        inputs:
+          targetType: filePath
+          filePath: './build/scripts/Set-ICUVersion.ps1'
+          arguments: '-icuVersionFile "$(BUILD.SOURCESDIRECTORY)\version.txt"'
+
+      - task: Docker@2
+        displayName: 'Setup Docker Container: $(distro)'
+        inputs:
+          command: build
+          Dockerfile: 'build/dockerfiles/$(distro)/Dockerfile'
+          arguments: -t ms-icu-container
+
+      - script: |
+          mkdir /tmp/build-output && docker run --rm -v $(pwd):/src -v /tmp/build-output:/dist ms-icu-container /src/build/scripts/build-icu.sh
+        displayName: 'Build, test, and make install'
+
+      - script: |
+          cd /tmp/build-output && ls -Rl
+        displayName: 'DIAG: ls -Rl'
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifacts'
+        inputs:
+          PathtoPublish: '/tmp/build-output/icu-binaries.tar.gz'
+          ArtifactName: 'linux_$(distro).tar.gz'
+
+      # Note: We only copy the .so files with the full version (ex: libicuuc.so.67.1.0.4)
+      - script: |
+          mkdir /tmp/icu-binaries
+          ls -al /tmp/build-output/icu/usr/local/lib/
+          cp /tmp/build-output/icu/usr/local/lib/libicudata.so.$(ICUVersion) /tmp/icu-binaries
+          cp /tmp/build-output/icu/usr/local/lib/libicui18n.so.$(ICUVersion) /tmp/icu-binaries
+          cp /tmp/build-output/icu/usr/local/lib/libicuuc.so.$(ICUVersion) /tmp/icu-binaries
+        displayName: 'Copy .so files'
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish: binaries'
+        inputs:
+          PathtoPublish: '/tmp/icu-binaries'
+          ArtifactName: 'linux-x64'
+
   - job: BuildWindows
+    timeoutInMinutes: 30
     pool:
       name: Azure Pipelines
       vmImage: 'vs2017-win2016'
@@ -176,6 +238,7 @@ stages:
     name: Package ES CodeHub Lab E
   jobs:
   - job: CodeSignBits
+    timeoutInMinutes: 30
     workspace:
       clean: all
     
@@ -257,6 +320,7 @@ stages:
 
   jobs:
   - job: CreateNugetAndCodeSign
+    timeoutInMinutes: 30
     workspace:
       clean: all
     steps:
@@ -305,6 +369,12 @@ stages:
       displayName: 'Download win-ARM64'
       inputs:
         artifactName: 'win-ARM64'
+        downloadPath: '$(Build.BINARIESDIRECTORY)\bits'
+
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download linux-x64'
+      inputs:
+        artifactName: 'linux-x64'
         downloadPath: '$(Build.BINARIESDIRECTORY)\bits'
 
     # Symbols (PDBs)

--- a/build/dockerfiles/centos/Dockerfile
+++ b/build/dockerfiles/centos/Dockerfile
@@ -1,0 +1,19 @@
+# This uses the DotNet CentOS 7 docker image to build.
+# https://github.com/dotnet/dotnet-buildtools-prereqs-docker
+
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-359e48e-20200313130914
+MAINTAINER Jeff Genovy <29107334+jefgen@users.noreply.github.com>
+LABEL com.github.microsoft.icu="centos-7"
+
+# Remove icu-dev, so it doesn't conflict.
+RUN yum -y remove libicu-devel
+
+# When we run the docker container we will mount the source repo here
+VOLUME /src
+
+# The output from make install will go here
+VOLUME /dist
+
+# Do the actual build in tmp
+RUN mkdir /tmp/build
+WORKDIR /tmp/build

--- a/build/nuget/SignConfig-ICU-Nuget.xml
+++ b/build/nuget/SignConfig-ICU-Nuget.xml
@@ -8,6 +8,7 @@
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x64*.nupkg" signType="Nuget" />
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x86*.nupkg" signType="Nuget" />
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-arm64*.nupkg" signType="Nuget" />
+    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.linux-x64*.nupkg" signType="Nuget" />
     <!-- Symbol packages -->
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x64*.snupkg" signType="Nuget" />
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x86*.snupkg" signType="Nuget" />

--- a/build/scripts/Set-ICUVersion.ps1
+++ b/build/scripts/Set-ICUVersion.ps1
@@ -28,6 +28,10 @@ $ICUVersion = $icuVersionData.ICU_version
 $vstsCommandString = 'vso[task.setvariable variable=ICUVersion]' + $ICUVersion
 Write-Host "##$vstsCommandString"
 
+# We also need to change the environment variable for the current PowerShell session
+# as this script may be called by other scripts.
+$env:ICUVersion = $ICUVersion
+
 # Sanity check on the ICU version number
 $icuVersionArray = $ICUVersion.split('.')
 if ($icuVersionArray.length -ne 4) {

--- a/build/scripts/build-icu.sh
+++ b/build/scripts/build-icu.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# echo commands when executing them
+set -x
+
+# Disable color output
+export TERM=xterm
+
+# Number of CPU Cores to use for make
+export CPUCORES=$(nproc)
+
+echo Building in: $(pwd)
+
+# Configure ICU for building. Skip layout[ex] and samples
+/src/icu/icu4c/source/runConfigureICU Linux --disable-layout --disable-layoutex --disable-samples || exit 1
+
+# Build, run the tests, then install into DESTDIR.
+make -j${CORES} check && make -j${CORES} DESTDIR=/dist/icu releaseDist || exit 1
+
+# Test that icuinfo works with the built libs in the installed location
+LD_LIBRARY_PATH=/dist/icu/usr/local/lib /dist/icu/usr/local/bin/icuinfo || exit 1
+
+# Copy OS Release (name of the distro) if it exists
+if [ -f /etc/os-release ];
+then
+    cat /etc/os-release
+    cp /etc/os-release /dist/icu
+fi
+
+# Copy the MS-ICU version number
+cp /src/version.txt /dist/icu
+
+# Pack up the binaries into a tarball
+cd /dist && tar -czpf icu-binaries.tar.gz -C /dist/icu .

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## ICU 67.1.0.5
+
+Code/general changes:
+- Enable building Linux x64 Nuget runtime package (for glibc based distros). [#27](https://github.com/microsoft/icu/pull/27)
+- Include the ICU major version number on PDB files (for common and i18n) to match the DLL filenames. [#26](https://github.com/microsoft/icu/pull/26)
+- Fix the build-time script Set-ICUVersion.ps1 to set the environment variable for the current session.
+
 ## ICU 67.1.0.4
 
 Code/general changes:

--- a/icu-patches/patches/013-MSFT-Patch-ICU_Add_version_number_to_PDB_names.patch
+++ b/icu-patches/patches/013-MSFT-Patch-ICU_Add_version_number_to_PDB_names.patch
@@ -1,0 +1,81 @@
+From 10e8c3a2fe8e46f29cf8cdf93ae1d536ab093a46 Mon Sep 17 00:00:00 2001
+From: Jeff Genovy <29107334+jefgen@users.noreply.github.com>
+Date: Thu, 6 Aug 2020 14:32:17 -0700
+Subject: [PATCH] MSFT-Patch: Add the ICU major version number to the PDB
+ filename to match the DLL filename.
+
+---
+ icu/icu4c/source/common/common.vcxproj     | 4 ++--
+ icu/icu4c/source/i18n/i18n.vcxproj         | 4 ++--
+ icu/icu4c/source/stubdata/stubdata.vcxproj | 4 ++--
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/icu/icu4c/source/common/common.vcxproj b/icu/icu4c/source/common/common.vcxproj
+index 5d9e70a..3ed76a8 100644
+--- a/icu/icu4c/source/common/common.vcxproj
++++ b/icu/icu4c/source/common/common.vcxproj
+@@ -76,7 +76,7 @@
+     </ClCompile>
+     <Link>
+       <OutputFile>..\..\$(IcuBinOutputDir)\icuuc67d.dll</OutputFile>
+-      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuucd.pdb</ProgramDatabaseFile>
++      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuuc67d.pdb</ProgramDatabaseFile>
+       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuucd.lib</ImportLibrary>
+       <!-- This forces dynamic linking of the UCRT. -->
+       <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>
+@@ -92,7 +92,7 @@
+     </ClCompile>
+     <Link>
+       <OutputFile>..\..\$(IcuBinOutputDir)\icuuc67.dll</OutputFile>
+-      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuuc.pdb</ProgramDatabaseFile>
++      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuuc67.pdb</ProgramDatabaseFile>
+       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuuc.lib</ImportLibrary>
+       <!-- This forces dynamic linking of the UCRT. -->
+       <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>
+diff --git a/icu/icu4c/source/i18n/i18n.vcxproj b/icu/icu4c/source/i18n/i18n.vcxproj
+index b6e539f..23ea405 100644
+--- a/icu/icu4c/source/i18n/i18n.vcxproj
++++ b/icu/icu4c/source/i18n/i18n.vcxproj
+@@ -78,7 +78,7 @@
+     <Link>
+       <AdditionalDependencies>icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+       <OutputFile>..\..\$(IcuBinOutputDir)\icuin67d.dll</OutputFile>
+-      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuind.pdb</ProgramDatabaseFile>
++      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuin67d.pdb</ProgramDatabaseFile>
+       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuind.lib</ImportLibrary>
+       <!-- This forces dynamic linking of the UCRT. -->
+       <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>
+@@ -95,7 +95,7 @@
+     <Link>
+       <AdditionalDependencies>icuuc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+       <OutputFile>..\..\$(IcuBinOutputDir)\icuin67.dll</OutputFile>
+-      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuin.pdb</ProgramDatabaseFile>
++      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuin67.pdb</ProgramDatabaseFile>
+       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuin.lib</ImportLibrary>
+       <!-- This forces dynamic linking of the UCRT. -->
+       <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>
+diff --git a/icu/icu4c/source/stubdata/stubdata.vcxproj b/icu/icu4c/source/stubdata/stubdata.vcxproj
+index 5e25345..c4e413a 100644
+--- a/icu/icu4c/source/stubdata/stubdata.vcxproj
++++ b/icu/icu4c/source/stubdata/stubdata.vcxproj
+@@ -59,7 +59,7 @@
+       <PrecompiledHeaderOutputFile>$(OutDir)/icudt.pch</PrecompiledHeaderOutputFile>
+       <AssemblerListingLocation>$(OutDir)/</AssemblerListingLocation>
+       <ObjectFileName>$(OutDir)/</ObjectFileName>
+-      <ProgramDataBaseFileName>$(OutDir)/icudt.pdb</ProgramDataBaseFileName>
++      <ProgramDataBaseFileName>$(OutDir)/icudt67.pdb</ProgramDataBaseFileName>
+     </ClCompile>
+     <ResourceCompile>
+       <PreprocessorDefinitions>STUBDATA_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+@@ -73,7 +73,7 @@
+       <TurnOffAssemblyGeneration>true</TurnOffAssemblyGeneration>
+       <!-- Note: stubdata is somewhat odd in that it doesn't suffix the Debug output DLL/LIB with a "d" like common/i18n/etc. -->
+       <OutputFile>..\..\$(IcuBinOutputDir)\icudt67.dll</OutputFile>
+-      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icudt.pdb</ProgramDatabaseFile>
++      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icudt67.pdb</ProgramDatabaseFile>
+       <ImportLibrary>..\..\$(IcuLibOutputDir)\icudt.lib</ImportLibrary>
+     </Link>
+   </ItemDefinitionGroup>
+-- 
+2.19.2
+

--- a/icu/icu4c/source/common/common.vcxproj
+++ b/icu/icu4c/source/common/common.vcxproj
@@ -76,7 +76,7 @@
     </ClCompile>
     <Link>
       <OutputFile>..\..\$(IcuBinOutputDir)\icuuc67d.dll</OutputFile>
-      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuucd.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuuc67d.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuucd.lib</ImportLibrary>
       <!-- This forces dynamic linking of the UCRT. -->
       <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>
@@ -92,7 +92,7 @@
     </ClCompile>
     <Link>
       <OutputFile>..\..\$(IcuBinOutputDir)\icuuc67.dll</OutputFile>
-      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuuc.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuuc67.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuuc.lib</ImportLibrary>
       <!-- This forces dynamic linking of the UCRT. -->
       <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>

--- a/icu/icu4c/source/common/unicode/uvernum.h
+++ b/icu/icu4c/source/common/unicode/uvernum.h
@@ -79,7 +79,7 @@
  *  @stable ICU 4.0
  */
 #ifndef U_ICU_VERSION_BUILDLEVEL_NUM
-#define U_ICU_VERSION_BUILDLEVEL_NUM 4
+#define U_ICU_VERSION_BUILDLEVEL_NUM 5
 #endif
 
 /** Glued version suffix for renamers
@@ -139,7 +139,7 @@
  *  This value will change in the subsequent releases of ICU
  *  @stable ICU 2.4
  */
-#define U_ICU_VERSION "67.1.0.4"
+#define U_ICU_VERSION "67.1.0.5"
 
 /**
  * The current ICU library major version number as a string, for library name suffixes.

--- a/icu/icu4c/source/i18n/i18n.vcxproj
+++ b/icu/icu4c/source/i18n/i18n.vcxproj
@@ -78,7 +78,7 @@
     <Link>
       <AdditionalDependencies>icuucd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>..\..\$(IcuBinOutputDir)\icuin67d.dll</OutputFile>
-      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuind.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuin67d.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuind.lib</ImportLibrary>
       <!-- This forces dynamic linking of the UCRT. -->
       <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>
@@ -95,7 +95,7 @@
     <Link>
       <AdditionalDependencies>icuuc.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>..\..\$(IcuBinOutputDir)\icuin67.dll</OutputFile>
-      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuin.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icuin67.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icuin.lib</ImportLibrary>
       <!-- This forces dynamic linking of the UCRT. -->
       <IgnoreSpecificDefaultLibraries>libucrtd.lib;libucrt.lib</IgnoreSpecificDefaultLibraries>

--- a/icu/icu4c/source/stubdata/stubdata.vcxproj
+++ b/icu/icu4c/source/stubdata/stubdata.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeaderOutputFile>$(OutDir)/icudt.pch</PrecompiledHeaderOutputFile>
       <AssemblerListingLocation>$(OutDir)/</AssemblerListingLocation>
       <ObjectFileName>$(OutDir)/</ObjectFileName>
-      <ProgramDataBaseFileName>$(OutDir)/icudt.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(OutDir)/icudt67.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>STUBDATA_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -73,7 +73,7 @@
       <TurnOffAssemblyGeneration>true</TurnOffAssemblyGeneration>
       <!-- Note: stubdata is somewhat odd in that it doesn't suffix the Debug output DLL/LIB with a "d" like common/i18n/etc. -->
       <OutputFile>..\..\$(IcuBinOutputDir)\icudt67.dll</OutputFile>
-      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icudt.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>.\..\..\$(IcuLibOutputDir)\icudt67.pdb</ProgramDatabaseFile>
       <ImportLibrary>..\..\$(IcuLibOutputDir)\icudt.lib</ImportLibrary>
     </Link>
   </ItemDefinitionGroup>

--- a/version.txt
+++ b/version.txt
@@ -35,5 +35,5 @@
 # in the header file "uvernum.h" whenever updated and/or changed.
 #
 
-ICU_version = 67.1.0.4
+ICU_version = 67.1.0.5
 ICU_upstream_hash = 125e29d54990e74845e1546851b5afa3efab06ce


### PR DESCRIPTION
## Summary
This updates the `maint/maint-67` branch to `67.1.0.5`.
(This will be done as a merge commit to keep the history).

Note: Once this is merged the MSCodeHub submodule can be updated. :)

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
