### PR TITLE
Produce debugging symbols for the Linux x64 binaries

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -54,12 +54,6 @@ stages:
           cd /tmp/build-output && ls -Rl
         displayName: 'DIAG: ls -Rl'
 
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifacts'
-        inputs:
-          PathtoPublish: '/tmp/build-output/icu-binaries.tar.gz'
-          ArtifactName: 'linux_$(distro).tar.gz'
-
       # Note: We only copy the .so files with the full version (ex: libicuuc.so.67.1.0.4)
       - script: |
           mkdir /tmp/icu-binaries
@@ -74,6 +68,20 @@ stages:
         inputs:
           PathtoPublish: '/tmp/icu-binaries'
           ArtifactName: 'linux-x64'
+
+      - script: |
+          mkdir /tmp/icu-symbols
+          ls -al /tmp/build-output/icu/usr/local/lib/
+          cp /tmp/build-output/icu/usr/local/lib/libicudata.so.$(ICUVersion).debug /tmp/icu-symbols
+          cp /tmp/build-output/icu/usr/local/lib/libicui18n.so.$(ICUVersion).debug /tmp/icu-symbols
+          cp /tmp/build-output/icu/usr/local/lib/libicuuc.so.$(ICUVersion).debug /tmp/icu-symbols
+        displayName: 'Copy debug symbols'
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish: symbols'
+        inputs:
+          PathtoPublish: '/tmp/icu-symbols'
+          ArtifactName: 'symbols-linux-x64'
 
   - job: BuildWindows
     timeoutInMinutes: 30


### PR DESCRIPTION
This change enables the creation of debugging symbols for the Linux x64 binaries that are part of the MS-ICU Nuget package.

In order to produce the debugging symbols for the Linux ELF binaries, we need to build the ICU library code with symbols support (ie: the `-g` compiler option).

We want to produce debugging symbols for "release" builds, but we don't want to use the `--enable-debug` flag/option with the `runConfigureICU` script, as that will turn on all kinds of debug code and asserts inside the ICU library code.

Instead we set the environment variables `CFLAGS` and `CXXFLAGS` (which are used by the compiler) to add the `-g` option. This lets us to do a full "release" build but still have symbols.

Debugging symbols are handled differently on Linux than Windows, and the debug symbols are actually *included* as part of the binary itself. (ie: This would be like if the `.dll` file also had all the info from the `.pdb` file included in it).

This means that once the library is built we need to strip off the debugging info from the `.so` binary into a separate file.
The convention for these "debugging symbols" files on Linux is to use the (aptly named) extension of "`.debug`".

The resulting symbol files are published as a build artifact named "`symbols-linux-x64`" on the CI pipeline.

To give a concrete example, the "linux-x64" artifact contains:
- `libicudata.so.67.1.0.5`
- `libicuuc.so.67.1.0.5`
- `libicui18n.so.67.1.0.5`

With this change, we'll now have a "symbols-linux-x64" artifact with the following files:
- `libicudata.so.67.1.0.5.debug`
- `libicuuc.so.67.1.0.5.debug`
- `libicui18n.so.67.1.0.5.debug`

This change also fixes the variable `CPUCORES` in the Docker build script, and removes the unneeded binary tarball.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
