### PR TITLE
Changes for publishing symbols.

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -404,6 +404,18 @@ stages:
         artifactName: 'symbols-win-ARM64'
         downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
 
+    # Publish the Windows Symbols to MSCodeHub
+    - task: PublishSymbols@2
+      displayName: 'Publish Windows Symbols to MSCodeHub'
+      inputs:
+        symbolsFolder: '$(Build.BINARIESDIRECTORY)\symbols'
+        searchPattern: '**/*.pdb'
+        SymbolsMaximumWaitTime: 30
+        SymbolServerType: 'TeamServices'
+        SymbolsProduct: 'MS-ICU Nuget Windows binaries'
+        SymbolsVersion: '$(ICUVersion)'
+      condition: and(succeeded(), eq(variables.codeSign, true))
+
     - powershell: |
         Write-Host ""
         Write-Host "$(BUILD.BINARIESDIRECTORY)"
@@ -418,7 +430,7 @@ stages:
       inputs:
         targetType: filePath
         filePath: './build/scripts/Create-Nuget-Runtime.ps1'
-        arguments: '-sourceRoot $(BUILD.SOURCESDIRECTORY) -icuBinaries "$(BUILD.BINARIESDIRECTORY)\bits" -icuSymbols "$(BUILD.BINARIESDIRECTORY)\symbols" -output $(BUILD.ArtifactStagingDirectory)\output -codesign $(codeSign)'
+        arguments: '-sourceRoot $(BUILD.SOURCESDIRECTORY) -icuBinaries "$(BUILD.BINARIESDIRECTORY)\bits" -output $(BUILD.ArtifactStagingDirectory)\output -codesign $(codeSign)'
 
     - powershell: |
         Write-Host ""
@@ -443,14 +455,6 @@ stages:
         Write-Host "Executing: $cmd"
         &cmd /c $cmd
       displayName: 'Verify Nuget Packages are Signed'
-      condition: and(succeeded(), eq(variables.codeSign, true))
-
-    # Check that the Nuget Symbol packages are also signed.
-    - powershell: |
-        $cmd = ('nuget verify -signature -CertificateFingerprint 3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE ' + $env:Build_ArtifactStagingDirectory + "\output\package\signed\*.snupkg")
-        Write-Host "Executing: $cmd"
-        &cmd /c $cmd
-      displayName: 'Verify Nuget Symbol Packages are Signed'
       condition: and(succeeded(), eq(variables.codeSign, true))
 
     - task: PublishBuildArtifacts@1

--- a/build/nuget/Template-runtime-meta.nuspec
+++ b/build/nuget/Template-runtime-meta.nuspec
@@ -15,6 +15,7 @@ ICU4C is a mature, widely used set of C/C++ libraries providing Unicode and Glob
 The MS-ICU repo contains a modified version of ICU4C with changes needed for consumption inside various Microsoft products.
 
 This runtime package only contains the common and i18n libraries, along with the data library.
+$symbolsLink$
 
 Note: For binary compatibility between versions see the page here: https://aka.ms/icu-binary-compatibility
     </description>


### PR DESCRIPTION
## Summary
It turns out that Nuget.org doesn't support "Nuget Symbol Packages" for native binaries at all.

They only support symbols for "managed" code (ie: C# or dotnet). If you try to upload a `.snupkg` that
contains native/C++ `.pdb` files in it, then it is rejected.

This means that we can't use Nuget.org for publish symbols at all, and instead need to find alternative methods.

Unfortunately, it turns that in order to publish symbols to the public `https://symweb` symbol server you need to
setup and maintain a corp-email-enabled domain service account, setup appropriate key storage in Azure Key Vault,
and then request special permission to publish using a PAT to push the symbols. This adds a ton of overhead.

In order to provide symbols but try to reduce the amount of overhead, we can upload the symbols to the GitHub
release page for a given MS-ICU version -- which does allows uploading any arbitrary zip files.

In the Nuget package nuspec we can then provide a direct link to the GitHub release page, so a user doesn't need
to hunt around on a wiki page to find the right symbols for a particular version. (Thanks to Axel for this idea).

This will let us provide debugging symbols for the Nuget packages (for both Windows and Linux) and the user only
has to click the link in the Nuget package description to find the downloads.

---

However, as an added bonus, it turns out that we can publish the Windows symbols to MSCodeHub -- which actually has its own symbols server. 

This means that for Windows users, they can add the following to their debugger symbol path:
```
https://mscodehub.artifacts.visualstudio.com/defaultcollection/_apis/symbol/symsrv
```
And then the correct symbols for any version will be resolved automatically. :)

This means that we can provide symbols two ways:
- For both Windows and Linux symbols:
  - On the GitHub release download page (with a direct link in the Nuget package).
- For just Windows symbols:
  - Using MSCodeHub's symbol server.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
