### PR TITLE
Bump the version number to 67.1.0.6, and update changelog.md

### DIFF
--- a/build/scripts/Set-ICUVersion.ps1
+++ b/build/scripts/Set-ICUVersion.ps1
@@ -50,12 +50,16 @@ foreach ($versionPart in $icuVersionArray) {
 $icuVersionHeader = (Get-Content "$PSScriptRoot\..\..\icu\icu4c\source\common\unicode\uvernum.h")
 $versionNumberDefine = '#define U_ICU_VERSION "'+ $ICUVersion +'"'
 if (!($icuVersionHeader -match $versionNumberDefine)) {
-    Write-Host "Error: The ICU Version number in uvernum.h does not match the value in the version.txt file".
+    Write-Host "Error: The ICU Version number (as a dotted-decimal string) in uvernum.h does not match the value in the version.txt file".
+    Write-Host "The uvernum.h file has the following instead:"
+    Write-Host $icuVersionHeader -match '#define U_ICU_VERSION "'
     throw "Error: ICU Version number mismatch!"
 }
 $buildVersionNumberDefine = '#define U_ICU_VERSION_BUILDLEVEL_NUM '+ $icuVersionArray[3]
 if (!($icuVersionHeader -match $buildVersionNumberDefine)) {
     Write-Host "Error: The ICU Build Version number in uvernum.h does not match the value in the version.txt file".
+    Write-Host "The uvernum.h file has the following instead:"
+    Write-Host $icuVersionHeader -match '#define U_ICU_VERSION_BUILDLEVEL_NUM "'
     throw "Error: ICU Version number mismatch!"
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## ICU 67.1.0.6
+
+Code/general changes:
+- Produce debugging symbols for MS-ICU Nuget package for both Windows and Linux. [#31](https://github.com/microsoft/icu/pull/31)
+
 ## ICU 67.1.0.5
 
 Code/general changes:

--- a/icu/icu4c/source/common/unicode/uvernum.h
+++ b/icu/icu4c/source/common/unicode/uvernum.h
@@ -79,7 +79,7 @@
  *  @stable ICU 4.0
  */
 #ifndef U_ICU_VERSION_BUILDLEVEL_NUM
-#define U_ICU_VERSION_BUILDLEVEL_NUM 5
+#define U_ICU_VERSION_BUILDLEVEL_NUM 6
 #endif
 
 /** Glued version suffix for renamers
@@ -139,7 +139,7 @@
  *  This value will change in the subsequent releases of ICU
  *  @stable ICU 2.4
  */
-#define U_ICU_VERSION "67.1.0.5"
+#define U_ICU_VERSION "67.1.0.6"
 
 /**
  * The current ICU library major version number as a string, for library name suffixes.

--- a/version.txt
+++ b/version.txt
@@ -35,5 +35,5 @@
 # in the header file "uvernum.h" whenever updated and/or changed.
 #
 
-ICU_version = 67.1.0.5
+ICU_version = 67.1.0.6
 ICU_upstream_hash = 125e29d54990e74845e1546851b5afa3efab06ce


### PR DESCRIPTION
## Summary
This change updates the version number `67.1.0.6` and the changelog.md file

This also makes the output from the `Set-ICUVersion.ps1` script more helpful if
the version number doesn't match.

Note: Once this is merged, I plan on creating a merge into the `maint/maint-67` branch,
and then pushing out a new Nuget package version and GitHub release.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
