### PR TITLE
Publish Windows debugging symbols for MS-ICU Nuget to the public Microsoft symbol server

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -404,18 +404,6 @@ stages:
         artifactName: 'symbols-win-ARM64'
         downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
 
-    # Publish the Windows Symbols to MSCodeHub
-    - task: PublishSymbols@2
-      displayName: 'Publish Windows Symbols to MSCodeHub'
-      inputs:
-        symbolsFolder: '$(Build.BINARIESDIRECTORY)\symbols'
-        searchPattern: '**/*.pdb'
-        SymbolsMaximumWaitTime: 30
-        SymbolServerType: 'TeamServices'
-        SymbolsProduct: 'MS-ICU Nuget Windows binaries'
-        SymbolsVersion: '$(ICUVersion)'
-      condition: and(succeeded(), eq(variables.codeSign, true))
-
     - powershell: |
         Write-Host ""
         Write-Host "$(BUILD.BINARIESDIRECTORY)"
@@ -462,6 +450,22 @@ stages:
       inputs:
         PathtoPublish: '$(BUILD.ArtifactStagingDirectory)\output\package'
         ArtifactName: 'Nuget_Packages'
+
+    # Publish the Windows Symbols to the public symbols server
+    - task: PublishSymbols@2
+      displayName: 'Publish Windows Symbols'
+      inputs:
+        symbolsFolder: '$(Build.BINARIESDIRECTORY)\symbols'
+        searchPattern: '**/*.pdb'
+        IndexSources: false
+        SymbolsMaximumWaitTime: 30
+        SymbolServerType: 'TeamServices'
+        SymbolsProduct: 'MS-ICU Nuget Windows binaries'
+        SymbolsVersion: '$(ICUVersion)'
+      condition: and(succeeded(), eq(variables.codeSign, true))
+      env:
+        ArtifactServices_Symbol_AccountName: microsoft
+        ArtifactServices_Symbol_UseAAD: true
 
     - task: PkgESSerializeForPostBuild@10
       displayName: 'PkgES Post Build Serialization'


### PR DESCRIPTION
## Summary
This change modifies the Nuget build pipeline to publish the debugging symbols for the Window pre-built binaries to the public Microsoft symbol server. This also moves the publishing step to be *after* the code signing steps, in case they might fail. (If they fail we don't want to publish the symbols).

This means that the symbols for the pre-built Windows binaries in the Nuget package can now be pulled from the public symbol server URLs:
- `https://msdl.microsoft.com/download/symbols` (external)
- `http://symweb` (internal)

Note: The authorization for this publishing step is based on the _individual user_ that manually triggers runs the pipeline run.
This means that we don't need to use a special service account or setup Azure Key vault storage for a custom PAT token.

Since we can use the public symbol server now, I also removed the publishing to the MSCodeHub artifact storage.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
