### PR TITLE
Update maint/maint-67 to 67.1.0.6

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -404,18 +404,6 @@ stages:
         artifactName: 'symbols-win-ARM64'
         downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
 
-    # Publish the Windows Symbols to MSCodeHub
-    - task: PublishSymbols@2
-      displayName: 'Publish Windows Symbols to MSCodeHub'
-      inputs:
-        symbolsFolder: '$(Build.BINARIESDIRECTORY)\symbols'
-        searchPattern: '**/*.pdb'
-        SymbolsMaximumWaitTime: 30
-        SymbolServerType: 'TeamServices'
-        SymbolsProduct: 'MS-ICU Nuget Windows binaries'
-        SymbolsVersion: '$(ICUVersion)'
-      condition: and(succeeded(), eq(variables.codeSign, true))
-
     - powershell: |
         Write-Host ""
         Write-Host "$(BUILD.BINARIESDIRECTORY)"
@@ -462,6 +450,22 @@ stages:
       inputs:
         PathtoPublish: '$(BUILD.ArtifactStagingDirectory)\output\package'
         ArtifactName: 'Nuget_Packages'
+
+    # Publish the Windows Symbols to the public symbols server
+    - task: PublishSymbols@2
+      displayName: 'Publish Windows Symbols'
+      inputs:
+        symbolsFolder: '$(Build.BINARIESDIRECTORY)\symbols'
+        searchPattern: '**/*.pdb'
+        IndexSources: false
+        SymbolsMaximumWaitTime: 30
+        SymbolServerType: 'TeamServices'
+        SymbolsProduct: 'MS-ICU Nuget Windows binaries'
+        SymbolsVersion: '$(ICUVersion)'
+      condition: and(succeeded(), eq(variables.codeSign, true))
+      env:
+        ArtifactServices_Symbol_AccountName: microsoft
+        ArtifactServices_Symbol_UseAAD: true
 
     - task: PkgESSerializeForPostBuild@10
       displayName: 'PkgES Post Build Serialization'

--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -54,12 +54,6 @@ stages:
           cd /tmp/build-output && ls -Rl
         displayName: 'DIAG: ls -Rl'
 
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifacts'
-        inputs:
-          PathtoPublish: '/tmp/build-output/icu-binaries.tar.gz'
-          ArtifactName: 'linux_$(distro).tar.gz'
-
       # Note: We only copy the .so files with the full version (ex: libicuuc.so.67.1.0.4)
       - script: |
           mkdir /tmp/icu-binaries
@@ -74,6 +68,20 @@ stages:
         inputs:
           PathtoPublish: '/tmp/icu-binaries'
           ArtifactName: 'linux-x64'
+
+      - script: |
+          mkdir /tmp/icu-symbols
+          ls -al /tmp/build-output/icu/usr/local/lib/
+          cp /tmp/build-output/icu/usr/local/lib/libicudata.so.$(ICUVersion).debug /tmp/icu-symbols
+          cp /tmp/build-output/icu/usr/local/lib/libicui18n.so.$(ICUVersion).debug /tmp/icu-symbols
+          cp /tmp/build-output/icu/usr/local/lib/libicuuc.so.$(ICUVersion).debug /tmp/icu-symbols
+        displayName: 'Copy debug symbols'
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish: symbols'
+        inputs:
+          PathtoPublish: '/tmp/icu-symbols'
+          ArtifactName: 'symbols-linux-x64'
 
   - job: BuildWindows
     timeoutInMinutes: 30

--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -404,6 +404,18 @@ stages:
         artifactName: 'symbols-win-ARM64'
         downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
 
+    # Publish the Windows Symbols to MSCodeHub
+    - task: PublishSymbols@2
+      displayName: 'Publish Windows Symbols to MSCodeHub'
+      inputs:
+        symbolsFolder: '$(Build.BINARIESDIRECTORY)\symbols'
+        searchPattern: '**/*.pdb'
+        SymbolsMaximumWaitTime: 30
+        SymbolServerType: 'TeamServices'
+        SymbolsProduct: 'MS-ICU Nuget Windows binaries'
+        SymbolsVersion: '$(ICUVersion)'
+      condition: and(succeeded(), eq(variables.codeSign, true))
+
     - powershell: |
         Write-Host ""
         Write-Host "$(BUILD.BINARIESDIRECTORY)"
@@ -418,7 +430,7 @@ stages:
       inputs:
         targetType: filePath
         filePath: './build/scripts/Create-Nuget-Runtime.ps1'
-        arguments: '-sourceRoot $(BUILD.SOURCESDIRECTORY) -icuBinaries "$(BUILD.BINARIESDIRECTORY)\bits" -icuSymbols "$(BUILD.BINARIESDIRECTORY)\symbols" -output $(BUILD.ArtifactStagingDirectory)\output -codesign $(codeSign)'
+        arguments: '-sourceRoot $(BUILD.SOURCESDIRECTORY) -icuBinaries "$(BUILD.BINARIESDIRECTORY)\bits" -output $(BUILD.ArtifactStagingDirectory)\output -codesign $(codeSign)'
 
     - powershell: |
         Write-Host ""
@@ -443,14 +455,6 @@ stages:
         Write-Host "Executing: $cmd"
         &cmd /c $cmd
       displayName: 'Verify Nuget Packages are Signed'
-      condition: and(succeeded(), eq(variables.codeSign, true))
-
-    # Check that the Nuget Symbol packages are also signed.
-    - powershell: |
-        $cmd = ('nuget verify -signature -CertificateFingerprint 3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE ' + $env:Build_ArtifactStagingDirectory + "\output\package\signed\*.snupkg")
-        Write-Host "Executing: $cmd"
-        &cmd /c $cmd
-      displayName: 'Verify Nuget Symbol Packages are Signed'
       condition: and(succeeded(), eq(variables.codeSign, true))
 
     - task: PublishBuildArtifacts@1

--- a/build/nuget/Template-runtime-meta.nuspec
+++ b/build/nuget/Template-runtime-meta.nuspec
@@ -15,6 +15,7 @@ ICU4C is a mature, widely used set of C/C++ libraries providing Unicode and Glob
 The MS-ICU repo contains a modified version of ICU4C with changes needed for consumption inside various Microsoft products.
 
 This runtime package only contains the common and i18n libraries, along with the data library.
+$symbolsLink$
 
 Note: For binary compatibility between versions see the page here: https://aka.ms/icu-binary-compatibility
     </description>

--- a/build/scripts/Set-ICUVersion.ps1
+++ b/build/scripts/Set-ICUVersion.ps1
@@ -50,12 +50,16 @@ foreach ($versionPart in $icuVersionArray) {
 $icuVersionHeader = (Get-Content "$PSScriptRoot\..\..\icu\icu4c\source\common\unicode\uvernum.h")
 $versionNumberDefine = '#define U_ICU_VERSION "'+ $ICUVersion +'"'
 if (!($icuVersionHeader -match $versionNumberDefine)) {
-    Write-Host "Error: The ICU Version number in uvernum.h does not match the value in the version.txt file".
+    Write-Host "Error: The ICU Version number (as a dotted-decimal string) in uvernum.h does not match the value in the version.txt file".
+    Write-Host "The uvernum.h file has the following instead:"
+    Write-Host $icuVersionHeader -match '#define U_ICU_VERSION "'
     throw "Error: ICU Version number mismatch!"
 }
 $buildVersionNumberDefine = '#define U_ICU_VERSION_BUILDLEVEL_NUM '+ $icuVersionArray[3]
 if (!($icuVersionHeader -match $buildVersionNumberDefine)) {
     Write-Host "Error: The ICU Build Version number in uvernum.h does not match the value in the version.txt file".
+    Write-Host "The uvernum.h file has the following instead:"
+    Write-Host $icuVersionHeader -match '#define U_ICU_VERSION_BUILDLEVEL_NUM "'
     throw "Error: ICU Version number mismatch!"
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## ICU 67.1.0.6
+
+Code/general changes:
+- Produce debugging symbols for MS-ICU Nuget package for both Windows and Linux. [#31](https://github.com/microsoft/icu/pull/31)
+
 ## ICU 67.1.0.5
 
 Code/general changes:

--- a/icu/icu4c/source/common/unicode/uvernum.h
+++ b/icu/icu4c/source/common/unicode/uvernum.h
@@ -79,7 +79,7 @@
  *  @stable ICU 4.0
  */
 #ifndef U_ICU_VERSION_BUILDLEVEL_NUM
-#define U_ICU_VERSION_BUILDLEVEL_NUM 5
+#define U_ICU_VERSION_BUILDLEVEL_NUM 6
 #endif
 
 /** Glued version suffix for renamers
@@ -139,7 +139,7 @@
  *  This value will change in the subsequent releases of ICU
  *  @stable ICU 2.4
  */
-#define U_ICU_VERSION "67.1.0.5"
+#define U_ICU_VERSION "67.1.0.6"
 
 /**
  * The current ICU library major version number as a string, for library name suffixes.

--- a/version.txt
+++ b/version.txt
@@ -35,5 +35,5 @@
 # in the header file "uvernum.h" whenever updated and/or changed.
 #
 
-ICU_version = 67.1.0.5
+ICU_version = 67.1.0.6
 ICU_upstream_hash = 125e29d54990e74845e1546851b5afa3efab06ce


### PR DESCRIPTION
## Summary
This updates the `maint/maint-67` branch to `67.1.0.6`.
(This will be done as a merge commit to keep the history).

Note: Once this is merged, I plan on creating a new GitHub release, and then pushing out a new Nuget package.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
