### PR TITLE
Remove Nuget symbol packages from Code Sign config file

### DIFF
--- a/build/nuget/SignConfig-ICU-Nuget.xml
+++ b/build/nuget/SignConfig-ICU-Nuget.xml
@@ -9,9 +9,5 @@
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x86*.nupkg" signType="Nuget" />
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-arm64*.nupkg" signType="Nuget" />
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.linux-x64*.nupkg" signType="Nuget" />
-    <!-- Symbol packages -->
-    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x64*.snupkg" signType="Nuget" />
-    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x86*.snupkg" signType="Nuget" />
-    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-arm64*.snupkg" signType="Nuget" />
   </job>
 </SignConfigXML>


### PR DESCRIPTION
## Summary
I missed this when removing the Nuget symbol packages. It causes warnings/errors during the Nuget code-sign build step, which causes the build to fail. 
I'll need to merge this into the `maint/maint-67` branch as well.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

