### PR TITLE
Update maint/maint-67 to pick up fix for Nuget code-sign config file

### DIFF
--- a/build/nuget/SignConfig-ICU-Nuget.xml
+++ b/build/nuget/SignConfig-ICU-Nuget.xml
@@ -9,9 +9,5 @@
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x86*.nupkg" signType="Nuget" />
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-arm64*.nupkg" signType="Nuget" />
     <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.linux-x64*.nupkg" signType="Nuget" />
-    <!-- Symbol packages -->
-    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x64*.snupkg" signType="Nuget" />
-    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-x86*.snupkg" signType="Nuget" />
-    <file src="__INPATHROOT__\Microsoft.ICU.ICU4C.Runtime.win-arm64*.snupkg" signType="Nuget" />
   </job>
 </SignConfigXML>


### PR DESCRIPTION
## Summary
Need to pick up the fix for the Nuget code sign config file (#35) in the `maint/maint-67` branch.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
