### PR TITLE
Reduce manual renaming of things need for new Releases

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -10,6 +10,7 @@ name: $(BuildDefinitionName)-$(date:yyMM).$(date:dd)$(rev:rrr)
 variables:
   codeSign: ${{ eq(variables['System.definitionId'], '1386') }}
   BuildConfiguration: 'Release'
+  nugetPackageName: 'Microsoft.ICU.ICU4C.Runtime'
 
 stages:
 - stage: Build
@@ -81,7 +82,7 @@ stages:
         displayName: 'Publish: symbols'
         inputs:
           PathtoPublish: '/tmp/icu-symbols'
-          ArtifactName: 'symbols-linux-x64'
+          ArtifactName: 'Symbols-$(nugetPackageName).linux-x64'
 
   - job: BuildWindows
     timeoutInMinutes: 30

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -26,11 +26,16 @@ jobs:
     - script: |
         cd icu/icu4c/source && make dist && ls -al dist
       displayName: 'Make dist'
+    - script: |
+        mkdir /tmp/icu-tarball
+        cp icu/icu4c/source/dist/icu4c-src.tgz /tmp/icu-tarball
+        mv /tmp/icu-tarball/icu4c-src.tgz /tmp/icu-tarball/msicu-icu4c-v$(ICUVersion)-src.tgz
+      displayName: 'Rename source tarball'
     - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifacts: icu4c-src.tgz'
+      displayName: 'Publish: Source tarball'
       inputs:
-        PathtoPublish: 'icu/icu4c/source/dist/icu4c-src.tgz'
-        ArtifactName: '$(Build.BuildNumber)_ICU4C_icu4c-src_tgz'
+        PathtoPublish: '/tmp/icu-tarball'
+        ArtifactName: '$(Build.BuildNumber)_ICU4C_tarball'
     - script: |
         cd icu/icu4c/source/dist
         timestampVar=`date +%s`
@@ -38,7 +43,7 @@ jobs:
         tar zxf icu4c-src.tgz -C /tmp/icu-$timestampVar
         cd /tmp/icu-$timestampVar/icu/source
         ./runConfigureICU Linux --disable-layout --disable-layoutex && make -j$(nproc) check
-      displayName: 'Build and Test MakeDist tarball'
+      displayName: 'Build and Test MakeDist using source tarball'
 
 #-------------------------------------------------------------------------
 - job: ICU4C_Clang_Ubuntu_1604_WarningsAsErrors

--- a/build/scripts/Create-Nuget-Runtime.ps1
+++ b/build/scripts/Create-Nuget-Runtime.ps1
@@ -58,12 +58,16 @@ if (!($localSHA)) {
 if (!(Test-Path 'env:ICUVersion')) {
     throw "Error: The ICU version environment variable is not set."
 }
+# We should already have the Nuget package name set as a environment variable.
+if (!(Test-Path 'env:nugetPackageName')) {
+    throw "Error: The Nuget package name environment variable is not set."
+}
 # We should already have the Nuget version set as a environment variable.
 if (!(Test-Path 'env:nugetPackageVersion')) {
     throw "Error: The Nuget version environment variable is not set."
 }
 
-$packageName = 'Microsoft.ICU.ICU4C.Runtime'
+$packageName = "$env:nugetPackageName"
 $packageVersion = "$env:nugetPackageVersion"
 
 if ($codesign -eq 'false') {


### PR DESCRIPTION
## Summary
This PR modifies the names of the published build artifacts slightly, in order to reduce the amount of manual renaming that is needed when creating a new Release on GitHub and Nuget.org.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
