### PR TITLE
Update the Component Governance task to use the new format.

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -294,11 +294,11 @@ stages:
         Tree /F /A $(BUILD.ArtifactStagingDirectory)
       displayName: 'DIAG: dir'
 
-    - task: ComponentGovernanceComponentDetection@0
+    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+      displayName: 'Component Governance Detection'
       inputs:
+        alertWarningLevel: Medium
         scanType: 'Register'
-        verbosity: 'Verbose'
-        alertWarningLevel: 'Medium'
         failOnAlert: true
 
     - task: PkgESCodeSign@10
@@ -426,6 +426,13 @@ stages:
         Write-Host "$(BUILD.ArtifactStagingDirectory)"
         Tree /F /A $(BUILD.ArtifactStagingDirectory)
       displayName: 'DIAG: dir'
+
+    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+      displayName: 'Component Governance Detection'
+      inputs:
+        alertWarningLevel: Medium
+        scanType: 'Register'
+        failOnAlert: true
 
     - task: PkgESCodeSign@10
       displayName: 'CodeSign MS-ICU Nuget'


### PR DESCRIPTION
## Summary
It seems the Component Governance task format has changed slightly, and the new format is required for Package ES code signing. This PR updates the format to use the new style.
(Note: This will need to be cherry-picked into the maint-67 branch as well.)

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
