### PR TITLE
Update Apache Ant to 1.10.9

### DIFF
--- a/icu/tools/cldr/cldr-to-icu/pom.xml
+++ b/icu/tools/cldr/cldr-to-icu/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.10.8</version>
+            <version>1.10.9</version>
         </dependency>
 
         <!-- Testing only dependencies. -->


### PR DESCRIPTION
## Summary
The new Component Governance task flagged Apache Ant as being out of date. The Apache Ant is only used as a build time dependency though, and only for the CLDR->ICU data conversion process -- so to be honest it doesn't really matter all that much for MS-ICU releases. However, since this is flagged as a security issue, we need to fix it by updating Ant to a newer version.
(Note: This will need to be cherry-picked into the maint-67 branch as well.)

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
