### PR TITLE
Cherry-pick Component Governance task update and Apache Ant update to maint/maint-67

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -293,11 +293,11 @@ stages:
         Tree /F /A $(BUILD.ArtifactStagingDirectory)
       displayName: 'DIAG: dir'
 
-    - task: ComponentGovernanceComponentDetection@0
+    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+      displayName: 'Component Governance Detection'
       inputs:
+        alertWarningLevel: Medium
         scanType: 'Register'
-        verbosity: 'Verbose'
-        alertWarningLevel: 'Medium'
         failOnAlert: true
 
     - task: PkgESCodeSign@10
@@ -425,6 +425,13 @@ stages:
         Write-Host "$(BUILD.ArtifactStagingDirectory)"
         Tree /F /A $(BUILD.ArtifactStagingDirectory)
       displayName: 'DIAG: dir'
+
+    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+      displayName: 'Component Governance Detection'
+      inputs:
+        alertWarningLevel: Medium
+        scanType: 'Register'
+        failOnAlert: true
 
     - task: PkgESCodeSign@10
       displayName: 'CodeSign MS-ICU Nuget'

--- a/icu/tools/cldr/cldr-to-icu/pom.xml
+++ b/icu/tools/cldr/cldr-to-icu/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.10.8</version>
+            <version>1.10.9</version>
         </dependency>
 
         <!-- Testing only dependencies. -->


### PR DESCRIPTION
## Summary
This change cherry-picks the two changes from PR #38 and PR #39 into the `maint/maint-67` branch.

Changes:
- Update the Component Governance task to use the new format.
- Update Apache Ant to 1.10.9

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
