### PR TITLE
Update symbols publishing to use the public server instead of the internal one

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -472,7 +472,7 @@ stages:
         SymbolsVersion: '$(ICUVersion)'
       condition: and(succeeded(), eq(variables.codeSign, true))
       env:
-        ArtifactServices_Symbol_AccountName: microsoft
+        ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
         ArtifactServices_Symbol_UseAAD: true
 
     - task: PkgESSerializeForPostBuild@10


### PR DESCRIPTION
## Summary
Thanks to @huichen123 for noticing this. We were actually publishing to the Microsoft internal server for symbols instead of the public one.
Note: I'll need to cherry-pick this change over to the `maint/maint-67` branch once I've tested that pipeline can actually publish correctly.


## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
