### PR TITLE
Cherry-pick PDB Symbols publishing change into maint/maint-67 branch

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -471,7 +471,7 @@ stages:
         SymbolsVersion: '$(ICUVersion)'
       condition: and(succeeded(), eq(variables.codeSign, true))
       env:
-        ArtifactServices_Symbol_AccountName: microsoft
+        ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
         ArtifactServices_Symbol_UseAAD: true
 
     - task: PkgESSerializeForPostBuild@10


### PR DESCRIPTION
## Summary
Note: This is a cherry-pick into the `maint/maint-67` branch from PR #41.

This updates the PDB symbols publishing to use the public server instead of the internal one.
(Thanks to @huichen123 for noticing this. We were actually publishing to the Microsoft internal server for symbols instead of the public one.)

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
