### PR TITLE
Update maint/maint-64 to 64.2.0.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## ICU 64.2.0.3
+
+Data changes:
+- Microsoft data changes to revise language names. [#46](https://github.com/microsoft/icu/pull/46).
+
 ## ICU 64.2.0.2
 
 Data changes:

--- a/version.txt
+++ b/version.txt
@@ -32,5 +32,5 @@
 # maint/maint-* branch needs to be cherry-picked into this repo.
 #
 
-ICU_version = 64.2.0.2
+ICU_version = 64.2.0.3
 ICU_upstream_hash = d4cb28ce9ceda0c8e7656be4d51e0b0d95685fd1


### PR DESCRIPTION
## Summary
This PR updates the `changelog.md` file and bumps the MS-ICU version number to `64.2.0.3`, in order to prepare for a new release.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
