### PR TITLE
Bump the version number to 67.1.0.7, and update changelog.md

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## ICU 67.1.0.7
+
+General changes:
+- Fix PDB symbol publishing to use public server instead of internal. [#42](https://github.com/microsoft/icu/pull/42).
+- CI build update to Component Governance task. [#40](https://github.com/microsoft/icu/pull/40).
+
+Data changes:
+- Microsoft data changes to revise language names. [#43](https://github.com/microsoft/icu/pull/43).
+
 ## ICU 67.1.0.6
 
 Code/general changes:

--- a/icu/icu4c/source/common/unicode/uvernum.h
+++ b/icu/icu4c/source/common/unicode/uvernum.h
@@ -79,7 +79,7 @@
  *  @stable ICU 4.0
  */
 #ifndef U_ICU_VERSION_BUILDLEVEL_NUM
-#define U_ICU_VERSION_BUILDLEVEL_NUM 6
+#define U_ICU_VERSION_BUILDLEVEL_NUM 7
 #endif
 
 /** Glued version suffix for renamers
@@ -139,7 +139,7 @@
  *  This value will change in the subsequent releases of ICU
  *  @stable ICU 2.4
  */
-#define U_ICU_VERSION "67.1.0.6"
+#define U_ICU_VERSION "67.1.0.7"
 
 /**
  * The current ICU library major version number as a string, for library name suffixes.

--- a/version.txt
+++ b/version.txt
@@ -35,5 +35,5 @@
 # in the header file "uvernum.h" whenever updated and/or changed.
 #
 
-ICU_version = 67.1.0.6
+ICU_version = 67.1.0.7
 ICU_upstream_hash = 125e29d54990e74845e1546851b5afa3efab06ce


### PR DESCRIPTION
## Summary
This change updates the version number `67.1.0.7` and the `changelog.md` file

Note: Once this is merged, I plan on creating a merge into the `maint/maint-67` branch,
and then pushing out a new Nuget package version and GitHub release.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
