### PR TITLE
[ICU 68.1 Update] The "tools/cldr/.gitignore" shouldn't ignore already checked-in files.

### DIFF
--- a/icu/tools/cldr/.gitignore
+++ b/icu/tools/cldr/.gitignore
@@ -1,6 +1,8 @@
 # Exclude the Maven local repository but keep the lib directory and the top-level readme.
 /lib/**
 !/lib/README.txt
+!/lib/install-cldr-jars.sh
+!/lib/pom.xml
 
 # Ignore the default Maven target directory.
 /cldr-to-icu/target

--- a/icu/tools/cldr/lib/install-cldr-jars.sh
+++ b/icu/tools/cldr/lib/install-cldr-jars.sh
@@ -1,0 +1,102 @@
+#!/bin/bash -u
+#
+#####################################################################
+### © 2020 and later: Unicode, Inc. and others.                   ###
+### License & terms of use: http://www.unicode.org/copyright.html ###
+#####################################################################
+#
+# This script will attempt to build and install the necessary CLDR JAR files
+# from a given CLDR installation root directory. The JAR files are installed
+# according to the manual instructions given in README.txt and lib/README.txt.
+#
+# The user must have installed both 'ant' and 'maven' in accordance with the
+# instructions in README.txt before attempting to run this script.
+#
+# Usage (from the directory of this script):
+#
+# ./install-cldr-jars.sh <CLDR-root-directory>
+#
+# Note to maintainers: This script cannot be assumed to run on a Unix/Linux
+# based system, and while a Posix compliant bash shell is required, any
+# assumptions about auxiliary Unix tools should be minimized (e.g. things
+# like "dirname" or "tempfile" may not exist). Where bash-only alternatives
+# have to be used, they should be clearly documented.
+
+# Exit with a message for fatal errors.
+function die() {
+  echo "$1"
+  echo "Exiting..."
+  exit 1
+} >&2
+
+# Runs a given command and captures output to the global log file.
+# If a command errors, the user can then view the log file.
+function run_with_logging() {
+  echo >> "${LOG_FILE}"
+  echo "Running: ${@}" >> "${LOG_FILE}"
+  echo -- "----------------------------------------------------------------" >> "${LOG_FILE}"
+  "${@}" >> "${LOG_FILE}" 2>&1
+  if (( $? != 0 )) ; then
+    echo -- "---- Previous command failed ----" >> "${LOG_FILE}"
+    echo "Error running: ${@}"
+    read -p "Show log file? " -n 1 -r
+    echo
+    if [[ "${REPLY}" =~ ^[Yy]$ ]] ; then
+      less -X "${LOG_FILE}"
+    fi
+    echo "Log file: ${LOG_FILE}"
+    exit 1
+  fi
+  echo -- "---- Previous command succeeded ----" >> "${LOG_FILE}"
+}
+
+# First require that we are run from the same directory as the script.
+# Can't assume users have "dirname" available so hack it a bit with shell
+# substitution (if no directory path was prepended, SCRIPT_DIR==$0).
+SCRIPT_DIR=${0%/*}
+if [[ "$SCRIPT_DIR" != "$0" ]] ; then
+  cd $SCRIPT_DIR
+fi
+
+# Check for some expected environmental things early.
+which ant > /dev/null || die "Cannot find Ant executable 'ant' in the current path."
+which mvn > /dev/null || die "Cannot find Maven executable 'mvn' in the current path."
+
+# Check there's one argument that points at a directory (or a symbolic link to a directory).
+(( $# == 1 )) && [[ -d "$1" ]] || die "Usage: ./install-cldr-jars.sh <CLDR-root-directory>"
+
+# Set up a log file (and be nice about tidying it up).
+# Cannot assume "tempfile" exists so use a timestamp (we expect "date" to exist though).
+LOG_FILE="${TMPDIR:-/tmp}/cldr2icu_log_$(date '+%m%d_%H%M%S').txt"
+touch $LOG_FILE || die "Cannot create temporary file: ${LOG_FILE}"
+echo -- "---- LOG FILE ---- $(date '+%F %T') ----" >> "${LOG_FILE}"
+
+# Build the cldr.jar in the CLDR tools directory.
+CLDR_TOOLS_DIR="$1/tools/java"
+pushd "${CLDR_TOOLS_DIR}" > /dev/null || die "Cannot change directory to: ${CLDR_TOOLS_DIR}"
+
+echo "Building CLDR JAR file..."
+run_with_logging ant -f ./build.xml clean jar
+[[ -f "cldr.jar" ]] || die "Error creating cldr.jar file"
+
+popd > /dev/null
+
+# The -B flag is "batch" mode and won't mess about with escape codes in the log file.
+echo "Installing CLDR JAR file..."
+run_with_logging mvn -B install:install-file \
+  -Dproject.parent.relativePath="" \
+  -DgroupId=org.unicode.cldr \
+  -DartifactId=cldr-api \
+  -Dversion=0.1-SNAPSHOT \
+  -Dpackaging=jar \
+  -DgeneratePom=true \
+  -DlocalRepositoryPath=. \
+  -Dfile="${CLDR_TOOLS_DIR}/cldr.jar"
+
+echo "Syncing local Maven repository..."
+run_with_logging mvn -B dependency:purge-local-repository \
+  -Dproject.parent.relativePath="" \
+  -DmanualIncludes=org.unicode.cldr:cldr-api:jar 
+
+echo "All done!"
+echo "Log file: ${LOG_FILE}"

--- a/icu/tools/cldr/lib/pom.xml
+++ b/icu/tools/cldr/lib/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- © 2020 and later: Unicode, Inc. and others.
+     License & terms of use: http://www.unicode.org/copyright.html
+     See README.txt for instructions on updating the local repository.
+     -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- This POM file acts as a parent POM file for any tool which is built
+         via Maven and requires access to the CLDR data APIs. This POM file
+         and the other files in this directory encapsulate the somewhat messy
+         task of including the Ant-built CLDR JAR file in Maven projects. -->
+
+    <!-- Declares this to be a POM that's included by other POM files. -->
+    <packaging>pom</packaging>    
+    
+    <!-- This must match any child POM file's <parent> declaration. -->         
+    <groupId>org.unicode.icu</groupId>
+    <artifactId>cldr-lib</artifactId>
+    <version>1.0</version>
+    
+    <!-- Important: The "${project.basedir}" property is the directory of the
+         child POM file, not this directory (and there's no easy way in Maven
+         to identify the absolute path of a parent POM file). However since
+         child POM files should have a <parent> declaration with the relative
+         path in it, we can use that. Note however that this is a bit fragile
+         and relies on <relativePath> being a directory, not a POM file.
+         
+         In order to allow the local repository to work either when it is used
+         by a child POM file or when it's used directly (e.g. for installing
+         or purging the cache) when it is invoked from this directory, the
+           -Dproject.parent.relativePath=""
+         argument must be given. -->
+    <repositories>
+        <repository>
+            <id>local-maven-repo</id>
+            <url>file://${project.basedir}/${project.parent.relativePath}</url>
+        </repository>
+    </repositories>
+    
+    <!-- Ant-built JAR file(s) installed into the local Maven repository in this
+         directory by the 'install-cldr-jars.sh' script. -->
+    <dependencies>
+        <dependency>
+            <groupId>org.unicode.cldr</groupId>
+            <artifactId>cldr-api</artifactId>
+            <version>0.1-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>
+


### PR DESCRIPTION
This is part 3 of N for updating to ICU 68.1.

It's generally considered a bad practice or an anti-pattern to have files checked-into a git repo which are at the same time also excluded by `.gitignore` file(s) in the repo as well.

These two files are used/needed by the CLDR-to-ICU data build process.

However, I accidentally removed them in the previous commit/PR, as there is a checked-in `.gitignore` file which excludes them. (This means when coping from one repo/clone to another repo/clone the files won't get added.)

This commit adds them back, and also add an exclusion to the `.gitignore` file so that they don't get ignored.

I filed an upstream ICU ticket for this here as well:
https://unicode-org.atlassian.net/browse/ICU-21427

Note: The CI builds for this PR will fail and that is expected. I will be updating the CI pipelines later on afterwards, but that needs to be done as a separate commit. For now I will bypass the checks.

## Summary

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.