### PR TITLE
[ICU 68.1 Update] Update Azure Nuget CI build to use VS2019

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -88,7 +88,7 @@ stages:
     timeoutInMinutes: 30
     pool:
       name: Azure Pipelines
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-2019'
       demands:
       - msbuild
       - visualstudio
@@ -137,7 +137,6 @@ stages:
       displayName: 'Build x64 first (Only if building ARM)'
       inputs:
         solution: icu/icu4c/source/allinone/allinone.sln
-        vsVersion: 15.0
         msbuildArgs: '/p:SkipUWP=true'
         platform: x64
         configuration: Release
@@ -147,7 +146,6 @@ stages:
       displayName: 'Build $(BuildPlatform)'
       inputs:
         solution: icu/icu4c/source/allinone/allinone.sln
-        vsVersion: 15.0
         msbuildArgs: '/p:SkipUWP=true'
         platform: '$(IcuBuildPlatform)'
         configuration: Release

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -125,13 +125,15 @@ jobs:
         CXX: clang++
 
 #-------------------------------------------------------------------------
+# VS 2019 Builds
+#-------------------------------------------------------------------------
 - job: ICU4C_MSVC_x64_Release_Distrelease
-  displayName: 'C: MSVC 64-bit Release (VS 2017) + Distrelease'
+  displayName: 'C: MSVC 64-bit Release (VS 2019) + Distrelease'
   timeoutInMinutes: 30
   workspace:
       clean: all
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
     demands: 
       - msbuild
       - visualstudio
@@ -172,12 +174,12 @@ jobs:
 
 #-------------------------------------------------------------------------
 - job: ICU4C_MSVC_x86_Release_Distrelease
-  displayName: 'C: MSVC 32-bit Release (VS 2017) + Distrelease'
+  displayName: 'C: MSVC 32-bit Release (VS 2019) + Distrelease'
   timeoutInMinutes: 30
   workspace:
       clean: all
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
     demands: 
       - msbuild
       - visualstudio
@@ -213,12 +215,12 @@ jobs:
 
 #-------------------------------------------------------------------------
 - job: ICU4C_MSVC_x64_ARM32_ARM64_Release_Distrelease
-  displayName: 'C: MSVC x64 ARM32 ARM64 Release (VS 2017) + Distrelease ARM64'
+  displayName: 'C: MSVC x64 ARM32 ARM64 Release (VS 2019) + Distrelease ARM64'
   timeoutInMinutes: 60
   workspace:
       clean: all
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
     demands: 
       - msbuild
       - visualstudio
@@ -266,12 +268,12 @@ jobs:
 
 #-------------------------------------------------------------------------
 - job: ICU4C_MSVC_x64_Release_TestDataFilter
-  displayName: 'C: MSVC 64-bit Release TestDataFilter (VS 2017)'
+  displayName: 'C: MSVC 64-bit Release TestDataFilter (VS 2019)'
   timeoutInMinutes: 30
   workspace:
       clean: all
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
     demands: 
       - msbuild
       - visualstudio
@@ -300,12 +302,12 @@ jobs:
 
 #-------------------------------------------------------------------------
 - job: ICU4C_MSVC_x86_Debug
-  displayName: 'C: MSVC 32-bit Debug (VS 2017)'
+  displayName: 'C: MSVC 32-bit Debug (VS 2019)'
   timeoutInMinutes: 60
   workspace:
       clean: all
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
     demands: 
       - msbuild
       - visualstudio

--- a/icu/icu4c/source/common/unicode/uvernum.h
+++ b/icu/icu4c/source/common/unicode/uvernum.h
@@ -79,7 +79,7 @@
  *  @stable ICU 4.0
  */
 #ifndef U_ICU_VERSION_BUILDLEVEL_NUM
-#define U_ICU_VERSION_BUILDLEVEL_NUM 0
+#define U_ICU_VERSION_BUILDLEVEL_NUM 1
 #endif
 
 /** Glued version suffix for renamers
@@ -139,7 +139,7 @@
  *  This value will change in the subsequent releases of ICU
  *  @stable ICU 2.4
  */
-#define U_ICU_VERSION "68.1"
+#define U_ICU_VERSION "68.1.0.1"
 
 /**
  * The current ICU library major version number as a string, for library name suffixes.

--- a/version.txt
+++ b/version.txt
@@ -35,5 +35,5 @@
 # in the header file "uvernum.h" whenever updated and/or changed.
 #
 
-ICU_version = 68.1.0.0
+ICU_version = 68.1.0.1
 ICU_upstream_hash = ceeb53ac786e3a9bcd2520af1d57f227b8baab90


### PR DESCRIPTION
## Summary
This is part 5 of N for updating to ICU 68.1.

This change updates the Azure CI configuration files to use VS 2019 (from VS 2017) for the build validation and the Nuget package. With this change the CI builds for MS-ICU should now be working and passing again.

This change also updates the MS-ICU version number to 68.1.0.1, since we have now diverged from the upstream unmodified source code, as we've now applied the MSFT patches in the previous change.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
