### PR TITLE
[ICU 68.1 Update] Patch CLDR-to-ICU data tool for Windows (Part 2)

### DIFF
--- a/icu-patches/patches/014-MSFT-Patch-CLDR_to_ICU_data_tool_Windows_changes_part2.patch
+++ b/icu-patches/patches/014-MSFT-Patch-CLDR_to_ICU_data_tool_Windows_changes_part2.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeff Genovy <29107334+jefgen@users.noreply.github.com>
+Date: Tue, 8 Dec 2020 12:07:27 -0800
+Subject: MSFT-PATCH: CLDR-to-ICU data tool changes for MS-ICU/Windows (Part 2)
+
+Windows only searches for .exe executables by default, so we can't just
+call "ant" and instead need to launch a cmd prompt to run it.
+
+The "&quot;" changes are needed in order double-quote the arguments
+that get passed to the JVM. Without this hack the arguments don't get
+quoted at all, which causes build failures as some of the variables
+which get replaced have embedded spaces in them.
+
+diff --git a/icu/tools/cldr/cldr-to-icu/build-icu-data.xml b/icu/tools/cldr/cldr-to-icu/build-icu-data.xml
+index a524e3dfbeb32e1d98069fb9696ebd1c1f9d8805..9e3520d70244285176908295ad902c4e7df99f0b 100644
+--- a/icu/tools/cldr/cldr-to-icu/build-icu-data.xml
++++ b/icu/tools/cldr/cldr-to-icu/build-icu-data.xml
+@@ -109,24 +109,34 @@
+          need to use CLDR_DIR at runtime to find the production data, this can all be
+          removed. -->
+     <target name="convert" depends="init-args, prepare-jar">
+-        <exec executable="ant" searchpath="true" failonerror="true">
++        <!-- MSFT-Change: Windows only searches for .exe executables by default, so we can't just
++             call "ant" here, and instead need to launch a cmd prompt to run it.
++             
++             The "&quot;" below is needed in order double-quote the arguments that get passed to
++             the JVM. Without this hack the arguments don't get quoted at all, which causes build
++             failures as some of the variables which get replaced below have embedded spaces in them.
++         -->
++        <exec executable="cmd.exe" searchpath="true" failonerror="true">
++            <arg value="/c"/>
++            <arg value="ant.bat"/>
+             <!-- The CLDR library wants CLDR_DIR set, to the data directory. -->
+             <env key="CLDR_DIR" value="${cldrDataDir}" />
+             <!-- Force inherit JAVA_HOME (this can be important). -->
+             <env key="JAVA_HOME" value="${javaHome}" />
+             <!-- Initial Ant command line with all the "interesting" bit in. -->
+-            <arg line="-f build-icu-data.xml convert-impl -DcldrDir=${cldrDataDir}"/>
++            <arg line="-f build-icu-data.xml convert-impl"/>
++            <arg value="&quot;-DcldrDir=${cldrDataDir}&quot;"/>
+             <!-- List all properties in the "convert-impl" task (except cldrDir). -->
+-            <arg value="-DoutDir=${outDir}"/>
+-            <arg value="-DspecialsDir=${specialsDir}"/>
+-            <arg value="-DoutputTypes=${outputTypes}"/>
+-            <arg value="-DicuVersion=${icuVersion}"/>
+-            <arg value="-DicuDataVersion=${icuDataVersion}"/>
+-            <arg value="-DcldrVersion=${cldrVersion}"/>
+-            <arg value="-DminDraftStatus=${minDraftStatus}"/>
+-            <arg value="-DlocaleIdFilter=${localeIdFilter}"/>
+-            <arg value="-DincludePseudoLocales=${includePseudoLocales}"/>
+-            <arg value="-DemitReport=${emitReport}"/>
++            <arg value="&quot;-DoutDir=${outDir}&quot;"/>
++            <arg value="&quot;-DspecialsDir=${specialsDir}&quot;"/>
++            <arg value="&quot;-DoutputTypes=${outputTypes}&quot;"/>
++            <arg value="&quot;-DicuVersion=${icuVersion}&quot;"/>
++            <arg value="&quot;-DicuDataVersion=${icuDataVersion}&quot;"/>
++            <arg value="&quot;-DcldrVersion=${cldrVersion}&quot;"/>
++            <arg value="&quot;-DminDraftStatus=${minDraftStatus}&quot;"/>
++            <arg value="&quot;-DlocaleIdFilter=${localeIdFilter}&quot;"/>
++            <arg value="&quot;-DincludePseudoLocales=${includePseudoLocales}&quot;"/>
++            <arg value="&quot;-DemitReport=${emitReport}&quot;"/>
+         </exec>
+     </target>
+ 

--- a/icu-patches/readme.md
+++ b/icu-patches/readme.md
@@ -49,7 +49,9 @@ Generally speaking the steps are:
 3. `git commit` your changes as a single stand alone commit. Make a note of the **SHA1 HASH** value for your new commit.
 4. Use the following command to create a new .patch file:
 
-    `git format-patch --keep-subject --no-stat --stdout --no-signature --zero-commit --full-index -1 <SHA1 HASH> > my-new-patch.patch`
+```
+git format-patch --keep-subject --no-stat --stdout --no-signature --zero-commit --full-index -1 <SHA1 HASH> > my-new-patch.patch
+```
 
 5. Rename your new patch file so that it is appropriately numbered and descriptive, for example "003-my-new-icu-change.patch".
 6. Copy the new patch file under the "patches" folder.
@@ -70,10 +72,13 @@ General steps:
 6. Note: Only add the files that you want to be part of the patch.
 6. `git commit -m "My ICU patch change"`
 7. Make a note of the New SHA1 hash value from your commit.
-7. `git format-patch --keep-subject --no-stat --stdout --no-signature --zero-commit --full-index -1 <New SHA1> > <patch filename>.patch`
-8. Rename the new patch file so that it is appropriately numbered and descriptive.
-9. Copy the new patch file under the "patches" folder.
-10. `git rebase --abort`
+8. Generate the new patch file with:
+```
+git format-patch --keep-subject --no-stat --stdout --no-signature --zero-commit --full-index -1 <New SHA1> > <patch filename>.patch
+```
+9. Rename the new patch file so that it is appropriately numbered and descriptive.
+10. Copy the new patch file under the "patches" folder.
+11. `git rebase --abort`
 
 At this point you have now isolated the changes from the squash-merge commit into a single patch file and you can create a new branch for adding and committing the patch file.
 

--- a/icu/tools/cldr/cldr-to-icu/build-icu-data.xml
+++ b/icu/tools/cldr/cldr-to-icu/build-icu-data.xml
@@ -109,24 +109,34 @@
          need to use CLDR_DIR at runtime to find the production data, this can all be
          removed. -->
     <target name="convert" depends="init-args, prepare-jar">
-        <exec executable="ant" searchpath="true" failonerror="true">
+        <!-- MSFT-Change: Windows only searches for .exe executables by default, so we can't just
+             call "ant" here, and instead need to launch a cmd prompt to run it.
+             
+             The "&quot;" below is needed in order double-quote the arguments that get passed to
+             the JVM. Without this hack the arguments don't get quoted at all, which causes build
+             failures as some of the variables which get replaced below have embedded spaces in them.
+         -->
+        <exec executable="cmd.exe" searchpath="true" failonerror="true">
+            <arg value="/c"/>
+            <arg value="ant.bat"/>
             <!-- The CLDR library wants CLDR_DIR set, to the data directory. -->
             <env key="CLDR_DIR" value="${cldrDataDir}" />
             <!-- Force inherit JAVA_HOME (this can be important). -->
             <env key="JAVA_HOME" value="${javaHome}" />
             <!-- Initial Ant command line with all the "interesting" bit in. -->
-            <arg line="-f build-icu-data.xml convert-impl -DcldrDir=${cldrDataDir}"/>
+            <arg line="-f build-icu-data.xml convert-impl"/>
+            <arg value="&quot;-DcldrDir=${cldrDataDir}&quot;"/>
             <!-- List all properties in the "convert-impl" task (except cldrDir). -->
-            <arg value="-DoutDir=${outDir}"/>
-            <arg value="-DspecialsDir=${specialsDir}"/>
-            <arg value="-DoutputTypes=${outputTypes}"/>
-            <arg value="-DicuVersion=${icuVersion}"/>
-            <arg value="-DicuDataVersion=${icuDataVersion}"/>
-            <arg value="-DcldrVersion=${cldrVersion}"/>
-            <arg value="-DminDraftStatus=${minDraftStatus}"/>
-            <arg value="-DlocaleIdFilter=${localeIdFilter}"/>
-            <arg value="-DincludePseudoLocales=${includePseudoLocales}"/>
-            <arg value="-DemitReport=${emitReport}"/>
+            <arg value="&quot;-DoutDir=${outDir}&quot;"/>
+            <arg value="&quot;-DspecialsDir=${specialsDir}&quot;"/>
+            <arg value="&quot;-DoutputTypes=${outputTypes}&quot;"/>
+            <arg value="&quot;-DicuVersion=${icuVersion}&quot;"/>
+            <arg value="&quot;-DicuDataVersion=${icuDataVersion}&quot;"/>
+            <arg value="&quot;-DcldrVersion=${cldrVersion}&quot;"/>
+            <arg value="&quot;-DminDraftStatus=${minDraftStatus}&quot;"/>
+            <arg value="&quot;-DlocaleIdFilter=${localeIdFilter}&quot;"/>
+            <arg value="&quot;-DincludePseudoLocales=${includePseudoLocales}&quot;"/>
+            <arg value="&quot;-DemitReport=${emitReport}&quot;"/>
         </exec>
     </target>
 


### PR DESCRIPTION
## Summary
This is part 6 of N for updating to ICU 68.1.

This change modifies/patches the CLDR-to-ICU data build tool so that it now actually works on Windows.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

## Detailed Description

This took an inordinate amount of time to track down and figure out what was going wrong...

The CLDR-to-ICU data build process added a new additional "convert" exec target to the Maven build file in ICU 68.1:
https://github.com/microsoft/icu/commit/c8d5a7cbe2c1cdc3bbe13d670df1e2ad5bff7d27#diff-9453860ff1b33b84a7384219248361d667fe1d0dc13d93e28a7c8381313d6e53

However, it turns out that some of the variables that are passed to Apache ANT have embedded spaces or periods in them. This causes the JVM to throw a `java.lang.IllegalArgumentException` error before ANT even starts up, as it doesn't allow/permit JVM variables (ie: ones that start with `-D`) to have spaces or periods in them.

Apache ANT is _supposed_ to automatically add double-quotes whenever you use `arg value` to pass a value.
However, it will _not_ add double-quotes if you use `arg line` to pass a whole line of things.

Unfortunately, it seems that if you mix both `arg line` and `arg value` in the same `exec` block, then ANT will stop adding double-quotes to `arg value`. Even more unfortunate is that there doesn't appear to be anything you can do about this. There is no option/config/etc. that you can change/tweak to have it add the quotes back.

The most common work-around is really a hack: You can add double-quotes yourself to the argument. However, since the Maven build file is XML, we need to XML Escape them as `&quot;` in order to preserve the character.

This change patches the CLDR-to-ICU data build Maven file to add the double-quotes, so that we can now build/rebuild the ICU data on Windows.

This change also adds a new MSFT-PATCH file, since we'll need to reapply this change whenever we onboard a new version of ICU.
