### PR TITLE
[ICU 68.1 Update] Add comments to closing endifs for Windows SDK Header tool script

### DIFF
--- a/icu-patches/patches/015-MSFT-Patch-ICU_Header_changes_for_Windows_part3.patch
+++ b/icu-patches/patches/015-MSFT-Patch-ICU_Header_changes_for_Windows_part3.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeff Genovy <29107334+jefgen@users.noreply.github.com>
+Date: Thu, 10 Dec 2020 13:31:59 -0800
+Subject: MSFT-PATCH: Add closing comments to ifdefs for Windows SDK header
+ tools
+
+The Windows SDK header tools need to have the closing #endif contain a
+comment for the opening #if so that it can match them up.
+
+diff --git a/icu/icu4c/source/common/unicode/uloc.h b/icu/icu4c/source/common/unicode/uloc.h
+index 3addb847e7fe6f822ac325314ae2214d18af035e..2c33c02bfd022ee9f25eecff5af1e36a430c41ef 100644
+--- a/icu/icu4c/source/common/unicode/uloc.h
++++ b/icu/icu4c/source/common/unicode/uloc.h
+@@ -841,7 +841,7 @@ typedef enum ULocAvailableType {
+    * @internal
+    */
+   ULOC_AVAILABLE_COUNT
+-#endif
++#endif // U_HIDE_INTERNAL_API
+ } ULocAvailableType;
+ 
+ /**
+diff --git a/icu/icu4c/source/i18n/unicode/unumberrangeformatter.h b/icu/icu4c/source/i18n/unicode/unumberrangeformatter.h
+index e28fe51aa6ae34331c8be12d7d45e9c107a767e8..a90861d9dd0c09fa73d539820eb4c24773bc2bb3 100644
+--- a/icu/icu4c/source/i18n/unicode/unumberrangeformatter.h
++++ b/icu/icu4c/source/i18n/unicode/unumberrangeformatter.h
+@@ -193,7 +193,7 @@ typedef enum UNumberRangeIdentityResult {
+      * @internal
+      */
+     UNUM_IDENTITY_RESULT_COUNT
+-#endif
++#endif // U_HIDE_INTERNAL_API
+ 
+ } UNumberRangeIdentityResult;
+ 

--- a/icu/icu4c/source/common/unicode/uloc.h
+++ b/icu/icu4c/source/common/unicode/uloc.h
@@ -841,7 +841,7 @@ typedef enum ULocAvailableType {
    * @internal
    */
   ULOC_AVAILABLE_COUNT
-#endif
+#endif // U_HIDE_INTERNAL_API
 } ULocAvailableType;
 
 /**

--- a/icu/icu4c/source/i18n/unicode/unumberrangeformatter.h
+++ b/icu/icu4c/source/i18n/unicode/unumberrangeformatter.h
@@ -193,7 +193,7 @@ typedef enum UNumberRangeIdentityResult {
      * @internal
      */
     UNUM_IDENTITY_RESULT_COUNT
-#endif
+#endif // U_HIDE_INTERNAL_API
 
 } UNumberRangeIdentityResult;
 


### PR DESCRIPTION
## Summary
This is part 8 of N for updating to ICU 68.1.

The Windows SDK header tool script relies on the `#endif` containing the name of opening macro in the `#if` statement, in order to match them up. It turns out that these two don't have comments on the closing endif, likely because the opening if statement is only 2-3 lines above it. This change adds the comment to closing tag in order to unbreak the header tool scripts.
This change also adds a MSFT-Patch file for the change as well.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

