### PR TITLE
[ICU 68.1 Update] Increase the build timeout for CI-Nuget builds

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -85,7 +85,7 @@ stages:
           ArtifactName: 'Symbols-$(nugetPackageName).linux-x64'
 
   - job: BuildWindows
-    timeoutInMinutes: 30
+    timeoutInMinutes: 60
     pool:
       name: Azure Pipelines
       vmImage: 'windows-2019'
@@ -245,7 +245,7 @@ stages:
     name: Package ES CodeHub Lab E
   jobs:
   - job: CodeSignBits
-    timeoutInMinutes: 30
+    timeoutInMinutes: 45
     workspace:
       clean: all
     
@@ -327,7 +327,7 @@ stages:
 
   jobs:
   - job: CreateNugetAndCodeSign
-    timeoutInMinutes: 30
+    timeoutInMinutes: 45
     workspace:
       clean: all
     steps:


### PR DESCRIPTION
## Summary
This is part 9 of N for updating to ICU 68.1.

This is a relatively minor change. I noticed that the ARM builds are now taking a bit longer, causing the CI build to occasionally timeout and require triggering a re-run. This change simply increases the timeout amount on the build CI config to allow more time for the ARM builds to finish.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
