### PR TITLE
[ICU 68.1 Update] Rebuild data using extra data from CLDR seed locales

### DIFF
--- a/icu/icu4c/source/data/coll/aa.txt
+++ b/icu/icu4c/source/data/coll/aa.txt
@@ -1,0 +1,17 @@
+﻿// © 2016 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
+aa{
+    collations{
+        standard{
+            Sequence{
+                "&B<t<<<T<s<<<S<e<<<E"
+                "&C<k<<<K<x<<<X<i<<<I"
+                "&D<q<<<Q<r<<<R"
+                "&G<o<<<O"
+                "&W<h<<<H"
+            }
+            Version{"38"}
+        }
+    }
+}

--- a/icu/icu4c/source/data/coll/cu.txt
+++ b/icu/icu4c/source/data/coll/cu.txt
@@ -2,4 +2,30 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 // Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
 cu{
+    collations{
+        standard{
+            Sequence{
+                "[caseLevel on]"
+                "[caseFirst upper]"
+                "[backwards 2]"
+                "[reorder Cyrl]"
+                "[suppressContractions [Ии]]"
+                "& [first secondary ignorable] = \u0487 = \uA67C = \uA67E << \u0485 << \u0486 << \u0301 << \u0300 << \u0311 << \u0483 << \u0306 << \u0308 = \u030F << \u2DF6 << \u2DE0 << \u2DE1 << \u2DE2 << \u2DE3 << \u2DF7 << \uA674 << \u2DE4 << \u2DE5 << \uA675 << \uA676 << \u2DE6 << \u2DE7 << \u2DE8 << \u2DE9 << \u2DEA << \uA67B << \u2DEB << \u2DEC << \u2DED << \u2DEE << \u2DF9 << \uA677 << \uA69E << \u2DEF << \u2DF0 << \u2DF1 << \u2DF2 << \u2DF3 << \u033E = \uA678 = \u2E2F << \uA679 << \uA67F = \uA67D = \uA67A << \u2DFA << \u2DFB << \u2DFE << \u2DFC << \u2DFD << \u2DF4"
+                "& \u2DED\u2DEE = \u2DF5"
+                "& д = \u1C81"
+                "& Е <<< є <<< Є"
+                "& ѕ < з = ꙁ <<< З = Ꙁ"
+                "& И < і <<< І"
+                "& Н < ѻ <<< Ѻ <<< о = \u1C82 <<< О <<< \u0461 <<< \u0460 <<< \uA64D <<< \uA64C"
+                "& \uA64C\u0486\u0311 = \u047C"
+                "& \uA64D\u0486\u0311 = \u047D"
+                "& Ѡт = Ѿ"
+                "& ѡт = ѿ"
+                "& Т < \u0479 = \u043E\u0443 = \u1C82\u0443 <<< \u0478 = \u041E\u0443 = \u041E\u0423 <<< \uA64B <<< \uA64A <<< \u0443 <<< \u0423"
+                "& Э < ѣ <<< Ѣ"
+                "& Ю < ѫ <<< Ѫ < я <<< Я < ꙗ <<< Ꙗ <<< ѧ <<< Ѧ < ѯ <<< Ѯ < ѱ <<< Ѱ < ѳ <<< Ѳ < ѵ <<< Ѵ"
+            }
+            Version{"38"}
+        }
+    }
 }

--- a/icu/icu4c/source/data/coll/nso.txt
+++ b/icu/icu4c/source/data/coll/nso.txt
@@ -1,0 +1,15 @@
+﻿// © 2016 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
+nso{
+    collations{
+        standard{
+            Sequence{
+                "&E<ê<<<Ê"
+                "&O<ô<<<Ô"
+                "&S<š<<<Š"
+            }
+            Version{"38"}
+        }
+    }
+}

--- a/icu/icu4c/source/data/coll/ssy.txt
+++ b/icu/icu4c/source/data/coll/ssy.txt
@@ -1,0 +1,17 @@
+﻿// © 2016 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
+ssy{
+    collations{
+        standard{
+            Sequence{
+                "&B<t<<<T<s<<<S<e<<<E"
+                "&C<k<<<K<x<<<X<i<<<I"
+                "&D<q<<<Q<r<<<R"
+                "&G<o<<<O"
+                "&W<h<<<H"
+            }
+            Version{"38"}
+        }
+    }
+}

--- a/icu/icu4c/source/data/coll/st.txt
+++ b/icu/icu4c/source/data/coll/st.txt
@@ -1,0 +1,5 @@
+﻿// © 2016 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
+st{
+}

--- a/icu/icu4c/source/data/coll/tn.txt
+++ b/icu/icu4c/source/data/coll/tn.txt
@@ -1,0 +1,15 @@
+﻿// © 2016 and later: Unicode, Inc. and others.
+// License & terms of use: http://www.unicode.org/copyright.html
+// Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
+tn{
+    collations{
+        standard{
+            Sequence{
+                "&E<ê<<<Ê"
+                "&O<ô<<<Ô"
+                "&S<š<<<Š"
+            }
+            Version{"38"}
+        }
+    }
+}

--- a/icu/icu4c/source/data/coll/vo.txt
+++ b/icu/icu4c/source/data/coll/vo.txt
@@ -2,4 +2,14 @@
 // License & terms of use: http://www.unicode.org/copyright.html
 // Generated using tools/cldr/cldr-to-icu/build-icu-data.xml
 vo{
+    collations{
+        standard{
+            Sequence{
+                "&A<ä<<<Ä"
+                "&O<ö<<<Ö"
+                "&U<ü<<<Ü"
+            }
+            Version{"38"}
+        }
+    }
 }

--- a/icu/tools/cldr/cldr-to-icu/build-icu-data.xml
+++ b/icu/tools/cldr/cldr-to-icu/build-icu-data.xml
@@ -347,7 +347,7 @@
                     root,
 
                     // A-B
-                    af, am, ars, ar, as, az, be, bg, bn, bo, br, bs_Cyrl, bs,
+                    aa, af, am, ars, ar, as, az, be, bg, bn, bo, br, bs_Cyrl, bs,
 
                     // C-F
                     ca, ceb, chr, ckb, ckb_IQ, ckb_IR, cs, cu, cy, da, de_AT, de, dsb, dz, ee, el, en,
@@ -359,14 +359,14 @@
 
                     // K-P
                     ka, kk, kl, km, kn, kok, ko, ku, ku_Arab_IQ, ku_Arab_IR, ky, lb, lkt, ln, lo, lt, lv,
-                    mk, ml, mn, mo, mr, ms, mt, my, nb, ne, nl, nn, no_NO, no,
+                    mk, ml, mn, mo, mr, ms, mt, my, nb, ne, nl, nn, no_NO, no, nso,
                     om, or, pa_IN, pa, pa_Guru, pl, prs, prs_AF, ps, pt,
 
                     // Q-T
                     qu, qu_BO, qu_EC, qu_PE, quc, quc_GT, qut, qut_Latn, qut_GT, qut_Latn_GT, quz, quz_BO, quz_EC, quz_PE
                     ro, ru, sa, se, sh_BA, sh_CS, sh, sh_YU, si, sk, sl, smn, sq,
-                    sr_BA, sr_Cyrl_ME, sr_Latn, sr_ME, sr_RS, sr, sv, sw,
-                    ta, te, th, tk, to, tr,
+                    sr_BA, sr_Cyrl_ME, sr_Latn, sr_ME, sr_RS, sr, ssy, st, sv, sw,
+                    ta, te, th, tk, tn, to, tr,
 
                     // U-Z
                     ug, uk, ur, uz, vi, vo, wae, wo, xh, yi, yo,


### PR DESCRIPTION
## Summary
This is part 11 of N for updating to ICU 68.1.

For the extra locales that we pull in from CLDR Seed (for parity with NLS, etc). we also want to pull in their data for annotations, casing, collation, rbnf, and transforms as well.

This change rebuilds the ICU data using the rebuilt CLDR-MS data from MSCodeHub.
See PR: https://mscodehub.visualstudio.com/OSS_github.com_Unicode-org/_git/ms-icu/pullrequest/13846

This change adds the collation data for the 5 seed locales (aa, nso, ssy, st, tn). which have data.

Note: I'm not going to list the other locales in the `build-icu-data.xml` file, as they don't have any data, and doing so makes the data build tool generated empty/stub files for them, which I don't think we want.

### Notes
For these new collations, we'll need to add the seed locales to the `IcuCollationNameToGuidIncrementJumplist.h` header for the ICU sorting adapter.

*Regarding add or removing collation GUIDs for NLS:*
In the NLS sorting paradigm, the GUIDs are effectively _tied_ to a particular NLS version number. Applications that care about reindexing are supposed to check _both_ the Version number and the GUID. If either change, then they need to reindex things.
(Though it's slightly more nuanced, as the set of GUIDs is shared in the registry for NLS for all versions. However, for the ICU-based sorting this doesn't apply.)

So as long as the major NLS version number is bumped, then additional and/or removal of GUIDs is fine.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

