### PR TITLE
Remove Nuget signing check from CI pipeline, as the CertificateFingerprint can change.

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -443,14 +443,6 @@ stages:
         outPathRoot: '$(BUILD.ArtifactStagingDirectory)\output\package'
       condition: and(succeeded(), eq(variables.codeSign, true))
 
-    # This checks that all the Nuget packages are signed.
-    - powershell: |
-        $cmd = ('nuget verify -signature -CertificateFingerprint 3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE ' + $env:Build_ArtifactStagingDirectory + "\output\package\signed\*.nupkg")
-        Write-Host "Executing: $cmd"
-        &cmd /c $cmd
-      displayName: 'Verify Nuget Packages are Signed'
-      condition: and(succeeded(), eq(variables.codeSign, true))
-
     - task: PublishBuildArtifacts@1
       displayName: 'Publish: Nuget Packages'
       inputs:


### PR DESCRIPTION
## Summary
This PR removes the Nuget signing check from the CI pipeline, as the CertificateFingerprint can change over time.
Having a hard-coded signature wasn't super useful anyways, as the Nuget.org site already validates that packages are signed when they are uploaded.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
