### PR TITLE
Cherry-pick 2 tickets after the ICU 68.2 release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,3 +13,13 @@ Changes/modifications compared to the upstream `maint/maint-68` branch.
 - Make `u_cleanup` a no-op for Windows OS ICU.
 - Conditionally set data file name based on `ICU_DATA_DIR_WINDOWS` to support Windows OS build with only a single data file.
 - Don't use the extended ICU data package for Windows OS build.
+
+#### Changes cherry-picked from upstream tickets/PRs:
+
+ICU-21427 Don't ignore already checked-in files under "tools/cldr/lib"
+- https://unicode-org.atlassian.net/browse/ICU-21427
+- https://github.com/unicode-org/icu/pull/1500
+
+ICU-21118 check that dst and src are not null in uprv_memcpy
+- https://unicode-org.atlassian.net/browse/ICU-21118
+- https://github.com/unicode-org/icu/pull/1489

--- a/icu/icu4c/source/common/cmemory.h
+++ b/icu/icu4c/source/common/cmemory.h
@@ -31,14 +31,25 @@
 #include <stddef.h>
 #include <string.h>
 #include "unicode/localpointer.h"
+#include "uassert.h"
 
 #if U_DEBUG && defined(UPRV_MALLOC_COUNT)
 #include <stdio.h>
 #endif
 
 
-#define uprv_memcpy(dst, src, size) U_STANDARD_CPP_NAMESPACE memcpy(dst, src, size)
-#define uprv_memmove(dst, src, size) U_STANDARD_CPP_NAMESPACE memmove(dst, src, size)
+#define uprv_memcpy(dst, src, size) UPRV_BLOCK_MACRO_BEGIN { \
+    U_ASSERT(dst != NULL); \
+    U_ASSERT(src != NULL); \
+    U_STANDARD_CPP_NAMESPACE memcpy(dst, src, size); \
+} UPRV_BLOCK_MACRO_END
+
+#define uprv_memmove(dst, src, size) UPRV_BLOCK_MACRO_BEGIN { \
+    U_ASSERT(dst != NULL); \
+    U_ASSERT(src != NULL); \
+    U_STANDARD_CPP_NAMESPACE memmove(dst, src, size); \
+} UPRV_BLOCK_MACRO_END
+
 
 /**
  * \def UPRV_LENGTHOF

--- a/icu/icu4c/source/common/uloc_tag.cpp
+++ b/icu/icu4c/source/common/uloc_tag.cpp
@@ -2028,7 +2028,10 @@ ultag_parse(const char* tag, int32_t tagLen, int32_t* parsedLen, UErrorCode* sta
         *status = U_MEMORY_ALLOCATION_ERROR;
         return NULL;
     }
-    uprv_memcpy(tagBuf, tag, tagLen);
+
+    if (tagLen > 0) {
+        uprv_memcpy(tagBuf, tag, tagLen);
+    }
     *(tagBuf + tagLen) = 0;
 
     /* create a ULanguageTag */

--- a/icu/tools/cldr/.gitignore
+++ b/icu/tools/cldr/.gitignore
@@ -1,4 +1,4 @@
-# Exclude the Maven local repository but keep the lib directory and the top-level readme.
+# Exclude the Maven local repository but keep the lib directory and the top-level readme, scripts and build config.
 /lib/**
 !/lib/README.txt
 !/lib/install-cldr-jars.sh


### PR DESCRIPTION
## Summary
This PR cherry-picks two tickets from the upstream ICU repo that were merged after the ICU 68.2 release.

- ICU-21427 Don't ignore already checked-in files under "tools/cldr/lib"
- ICU-21118 check that dst and src are not null in uprv_memcpy

The first one I had already done with https://github.com/microsoft/icu/pull/52, so this is mostly just making an update for the comments and to record it in the `changelog.md` file.

The second one was fixed by @erik0686, and prevents undefined behavior in `ultag_parse`.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
