### PR TITLE
Bump version number to 68.2.0.1, and update changelog.md

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## ICU 68.1.0.1
+## ICU 68.2.0.2
+#### Changes cherry-picked from upstream tickets/PRs:
+
+ICU-21465 Windows Time Zone offset is wrong when Automatic DST setting is OFF
+- https://unicode-org.atlassian.net/browse/ICU-21465
+- https://github.com/unicode-org/icu/pull/1465
+
+ICU-21449 Infinite loop can occur with locale IDs that contain RES_PATH_SEPARATOR
+- https://unicode-org.atlassian.net/browse/ICU-21449
+- https://github.com/unicode-org/icu/pull/1549
+
+## ICU 68.2.0.1
 
 Changes/modifications compared to the upstream `maint/maint-68` branch.
 

--- a/icu/icu4c/source/common/unicode/uvernum.h
+++ b/icu/icu4c/source/common/unicode/uvernum.h
@@ -79,7 +79,7 @@
  *  @stable ICU 4.0
  */
 #ifndef U_ICU_VERSION_BUILDLEVEL_NUM
-#define U_ICU_VERSION_BUILDLEVEL_NUM 1
+#define U_ICU_VERSION_BUILDLEVEL_NUM 2
 #endif
 
 /** Glued version suffix for renamers
@@ -139,7 +139,7 @@
  *  This value will change in the subsequent releases of ICU
  *  @stable ICU 2.4
  */
-#define U_ICU_VERSION "68.2.0.1"
+#define U_ICU_VERSION "68.2.0.2"
 
 /**
  * The current ICU library major version number as a string, for library name suffixes.

--- a/version.txt
+++ b/version.txt
@@ -35,5 +35,5 @@
 # in the header file "uvernum.h" whenever updated and/or changed.
 #
 
-ICU_version = 68.2.0.1
+ICU_version = 68.2.0.2
 ICU_upstream_hash = 84e1f26ea77152936e70d53178a816dbfbf69989


### PR DESCRIPTION
## Summary
This change updates the version number `68.2.0.2` and the `changelog.md` file, as we've cherry-picked two fixes from upstream ICU.

Note: Once this is merged, I plan on creating a merge into the `maint/maint-68` branch, and then updating the MSCodeHub to pull in the new version.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
