### PR TITLE
Add support for pre-built Linux ARM64 binaries for the MS-ICU Nuget.

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -22,11 +22,14 @@ stages:
     workspace:
       clean: all
 
-    # Note: We only have one distro for now, but this lets others be added more easily in the future.
     strategy:
       matrix:
         centos:
           distro: 'centos'
+          BuildPlatform: 'x64'
+        arm64:
+          distro: 'ubuntu-arm64'
+          BuildPlatform: 'arm64'
 
     steps:
       - checkout: self
@@ -45,11 +48,11 @@ stages:
         inputs:
           command: build
           Dockerfile: 'build/dockerfiles/$(distro)/Dockerfile'
-          arguments: -t ms-icu-container
+          arguments: -t ms-icu-container-$(BuildPlatform)
 
       - script: |
-          mkdir /tmp/build-output && docker run --rm -v $(pwd):/src -v /tmp/build-output:/dist ms-icu-container /src/build/scripts/build-icu.sh
-        displayName: 'Build, test, and make install'
+          pwd && mkdir -p /tmp/build-output && docker run --rm -v $(pwd):/src -v /tmp/build-output:/dist ms-icu-container-$(BuildPlatform) /src/build/scripts/build-icu-$(BuildPlatform).sh
+        displayName: 'Configure ICU and Build'
 
       - script: |
           cd /tmp/build-output && ls -Rl
@@ -68,7 +71,7 @@ stages:
         displayName: 'Publish: binaries'
         inputs:
           PathtoPublish: '/tmp/icu-binaries'
-          ArtifactName: 'linux-x64'
+          ArtifactName: 'linux-$(BuildPlatform)'
 
       - script: |
           mkdir /tmp/icu-symbols
@@ -82,7 +85,7 @@ stages:
         displayName: 'Publish: symbols'
         inputs:
           PathtoPublish: '/tmp/icu-symbols'
-          ArtifactName: 'Symbols-$(nugetPackageName).linux-x64'
+          ArtifactName: 'Symbols-$(nugetPackageName).linux-$(BuildPlatform)'
 
   - job: BuildWindows
     timeoutInMinutes: 60
@@ -359,7 +362,7 @@ stages:
         Tree /F /A $(BUILD.BINARIESDIRECTORY)
       displayName: 'DIAG: dir'
 
-    # Binaries (DLLs)
+    # Binaries (.dll or .so files)
     - task: DownloadBuildArtifacts@0
       displayName: 'Download win-x86'
       inputs:
@@ -382,6 +385,12 @@ stages:
       displayName: 'Download linux-x64'
       inputs:
         artifactName: 'linux-x64'
+        downloadPath: '$(Build.BINARIESDIRECTORY)\bits'
+
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download linux-arm64'
+      inputs:
+        artifactName: 'linux-arm64'
         downloadPath: '$(Build.BINARIESDIRECTORY)\bits'
 
     # Symbols (PDBs)

--- a/build/dockerfiles/ubuntu-arm64/Dockerfile
+++ b/build/dockerfiles/ubuntu-arm64/Dockerfile
@@ -1,13 +1,13 @@
-# This uses the .NET Core CentOS 7 docker image to build.
+# This uses the .NET Core Ubuntu 16.04 (xenial) Cross-ARM64 docker image to build.
 # https://github.com/dotnet/dotnet-buildtools-prereqs-docker
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-359e48e-20200313130914
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-20210106160011-b2c2436
 
 LABEL maintainer="Jeff Genovy <29107334+jefgen@users.noreply.github.com>"
-LABEL com.github.microsoft.icu="centos-7"
+LABEL com.github.microsoft.icu="ubuntu-16.04-cross-arm64"
 
 # Remove icu-dev, so it doesn't conflict.
-RUN yum -y remove libicu-devel
+RUN apt-get -y remove libicu-dev icu-devtools
 
 # When we run the docker container we will mount the source repo here
 VOLUME /src

--- a/build/scripts/build-icu-arm64.sh
+++ b/build/scripts/build-icu-arm64.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+# -e            Exit immediately if a command exits with a non-zero status
+# -u            Treat unset variables as an error
+# -x            Echo commands when executing them
+# -o pipefile   All commands in a pipeline must pass with non-zero status
+set -euxo pipefail
+
+# Disable color output
+export TERM=xterm
+
+# ----------------------------------------------------------------------------------
+# Common variables
+# The docker container should be setup with the ICU source under /src
+# Output will be under /dist
+
+# The top-level directory for the repo.
+ICU_SRC="/src"
+
+# Number of CPU Cores to use for make
+CPU_CORES=$(nproc)
+
+# This is the location CrossRootFS location in the .NET docker image
+# This location should contain the GNU GCC toolchain, libs, etc. for ARM64.
+CROSSROOT="/crossrootfs/arm64"
+
+# This is the target-triple that is used by clang/gcc, and the crossrootfs.
+TARGET_ARCH="aarch64-linux-gnu"
+
+# Build ICU under this location (out-of-source build).
+
+BUILD_DIR=/tmp/build
+HOST_BUILD_DIR="${BUILD_DIR}/host"
+TARGET_BUILD_DIR="${BUILD_DIR}/target"
+
+# Install the target ICU build under this location.
+DEST_DIR="/dist/icu"
+
+# ----------------------------------------------------------------------------------
+# Remove libicu-dev from the crossrootfs
+# The .NET Core docker image has the icu-dev package installed in the crossrootfs,
+# which we don't want. (.NET needs it for building, but we are actually building
+# ICU itself, so we don't want it to conflict).
+# Note that we can not use package managers like `apt` or `yum` to remove it
+# since they will only change or remove things from the _host_ filesystem.
+# Whereas the crossrootfs filesystem is really just a special directory that is
+# already built/setup ahead of time. This means that we must *manually* remove it.
+
+# icu-config
+rm -f ${CROSSROOT}/usr/bin/icu-config
+rm -f ${CROSSROOT}/usr/bin/icuinfo
+
+# headers
+rm -rf ${CROSSROOT}/usr/include/${TARGET_ARCH}/unicode/*
+rm -rf ${CROSSROOT}/usr/include/${TARGET_ARCH}/layout/*
+
+# libs
+rm -rf ${CROSSROOT}/usr/lib/${TARGET_ARCH}/icu/*
+rm -rf ${CROSSROOT}/usr/lib/${TARGET_ARCH}/libicu*
+
+# pkgconfig
+rm -rf ${CROSSROOT}/usr/lib/${TARGET_ARCH}/pkgconfig/icu-*
+
+# config
+rm -rf ${CROSSROOT}/usr/share/icu/*
+
+# ----------------------------------------------------------------------------------
+# We need to use Clang for cross-compiling.
+# Note that this particular .NET docker image doesn't have a symlink for 'clang',
+# so we need to specify the exact version here instead.
+export CC=clang-9
+export CXX=clang++-9
+
+# ----------------------------------------------------------------------------------
+# Host build
+
+# For the host build, we mostly just need the tools, so we can disable some options
+# that aren't needed in order to save a bit of build time.
+mkdir -p ${HOST_BUILD_DIR} && cd ${HOST_BUILD_DIR} && ${ICU_SRC}/icu/icu4c/source/runConfigureICU Linux \
+ --disable-icu-config \
+ --disable-extras \
+ --disable-tests \
+ --disable-layout \
+ --disable-layoutex \
+ --disable-samples \
+
+make -j${CPU_CORES} all
+
+# ----------------------------------------------------------------------------------
+# Target build
+
+# Note: We must set both the "sysroot" and the "gcc-toolchain".
+SHARED_COMPILER_ARGS="--target=$TARGET_ARCH --sysroot=$CROSSROOT --gcc-toolchain=${CROSSROOT}/usr"
+
+# We want to produce debugging symbols for "release" builds, but we don't want to use
+# the "--enable-debug" option with runConfigureICU, as that will turn on all kinds of
+# debug asserts inside the ICU library code.
+DEFINES="-g"
+
+export CFLAGS="$DEFINES $SHARED_COMPILER_ARGS"
+export CXXFLAGS="$DEFINES $SHARED_COMPILER_ARGS"
+
+# Linker flags
+# We need to tell the linker to look under the crossrootfs for shared libraries.
+export LDFLAGS="-Wl,--rpath-link=${CROSSROOT}/lib/${TARGET_ARCH}:${CROSSROOT}/usr/lib/${TARGET_ARCH}"
+
+# For building ICU for the ARM64 Nuget, we only really need: libicuuc, libicuin, libicudata
+# So we can turn of unneeded options in order to save a bit of build time.
+ICU_CONFIG_ARGS="--disable-icu-config --disable-extras --disable-tests --disable-layout --disable-layoutex --disable-samples --disable-icuio"
+
+# IMPORTANT NOTE: This is rather confusing. Clang uses the term 'host' to refer to the platform that
+# is doing the building, and 'target' to refer to the platform on which the resulting binaries will run.
+#
+# However, the GNU AutoConf script used by ICU *swaps* these terms, and uses the term 'host' to mean
+# the platform on which the resulting binaries will run.
+# That's why we have the confusing option `host=target` in the argument list below.
+ICU_CONFIG_CROSSBUILD_ARGS="--with-cross-build=$HOST_BUILD_DIR --host=$TARGET_ARCH"
+
+# Clean the output ARM64 build dir.
+rm -rf $TARGET_BUILD_DIR && mkdir -p $TARGET_BUILD_DIR && cd $TARGET_BUILD_DIR
+
+${ICU_SRC}/icu/icu4c/source/configure $ICU_CONFIG_ARGS $ICU_CONFIG_CROSSBUILD_ARGS \
+ CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" CC="$CC" CXX="$CXX"
+
+make -j${CPU_CORES} all 2>&1 | tee make-output.log
+
+# Clean the output dir.
+rm -rf $DEST_DIR && mkdir -p $DEST_DIR
+
+# Install into DEST_DIR.
+echo "Done building, installing into $DEST_DIR ..."
+make -j${CPU_CORES} DESTDIR=${DEST_DIR} releaseDist 2>&1 | tee make-install.log
+
+# Split out the debugging symbols from the libs
+ls -al ${DEST_DIR}/usr/local/lib
+
+for file in ${DEST_DIR}/usr/local/lib/lib*.so*; do
+    if [[ -L "$file" ]]; then echo "Skipping symlink $file";
+    else
+        echo "Stripping symbols for $file"
+        aarch64-linux-gnu-objcopy --only-keep-debug "$file" "$file.debug"
+        aarch64-linux-gnu-objcopy --strip-debug "$file"
+        aarch64-linux-gnu-objcopy --add-gnu-debuglink="$file.debug" "$file"
+    fi
+done
+
+ls -al ${DEST_DIR}/usr/local/lib


### PR DESCRIPTION
## Summary
This adds support for creating pre-built binaries for Linux ARM64, for use in the MS-ICU Nuget package.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

## Detailed Description
This change adds support for building pre-built binaries for Linux ARM64, for use in the MS-ICU Nuget package.

The binaries are cross-compiled inside of a Docker container, extracted, published as intermediate artifacts, and then packaged up into a Nuget package in the build pipeline, and finally published again.

The container used is from the .NET Core build tools, from https://github.com/dotnet/dotnet-buildtools-prereqs-docker
The shared libraries are built for the "`aarch64-linux-gnu`" target platform using the same base OS (Ubuntu 16.04 (xenial)) and CrossRoot FileSystem that is used for building the .NET Core Linux ARM64 binaries. This means they should work together without issue, and have the same dependencies, etc.

There were several interesting gotchas that took a bit to sort out:
- We need to double build ICU. We build it first for the host, and then second for the actual target (ARM64). The host build is needed in order to reuse the various ICU tools for building the data file(s) for the target OS.
- Rather confusingly, the GNU Autoconf tools use the _opposite terms_ for host/target than what the Clang compiler does. (This means that we have a line in the build where we set the host=target).
- Since ICU does not build with something like CMAKE, we need to manually set all the various compiler and linker flags.
- The .NET Docker image has `libicu-dev` installed in the CrossRootFS location, which causes confusion when building. We need to remove it, but have to do so manually as we can't use any package manager tools to manipulate the pre-built CrossRootFS.
- We need to set both the `sysroot` and the `gcc-toolchain` settings for the compiler.
- We need to explicitly tell the linker to look in the CrossRootFS 

This change also does the following:
- Renames the build scripts to include the BuildPlatform.
- Change the tag on the docker container to include the BuildPlatform.
- Updates the deprecated MAINTAINER field from the dockerfile for Centos.
  See: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

## Testing
For testing, I setup a totally separate Linux desktop PC in order to get the QEMU emulator working. This emulator is able to support different hardware, so it can emulate ARM64 on x64 for example. I was able to get Ubuntu working inside an ARM64 VM, and installed .NET Core 5 in the VM to test using the AppLocal ICU feature with the ARM64 Nuget package.
(Aside: However, the QEMU VM is far too slow to build inside of...)

Using `file` on the `.so` files in the VM shows that they are indeed `aarch64` binaries:

```shell
$ file libicuuc.so.68.2.0.2
libicuuc.so.68.2.0.2: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, BuildID[sha1]=efe6ba9476b5793dcb72e82cd8785946aa9466c1, not stripped
```

I used `scp` to copy the ARM64 Nuget bits into the VM for testing, and created a test app in C# to verify that the MS-ICU Nuget was being loaded and used.
I put the test app code in a repo here: https://github.com/jefgen/dotnet-icu-testApp/blob/master/Program.cs 

You can see the resulting output from the test app in the QEMU in the screenshot below:
![image](https://user-images.githubusercontent.com/29107334/109356857-29d00d80-7836-11eb-92f1-bf49c00d6699.png)

[cc: @safern & @tarekgh as FYI]