### PR TITLE
Cherry-pick: ICU-21492 Fix regex compile assertion failure.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@ CLDR-14476 fa, remove explicit <LRM> or replace with \u200E; ko, remove a bogus 
 - https://unicode-org.atlassian.net/browse/CLDR-14476
 - https://github.com/unicode-org/cldr/pull/1025
 
+ICU-21492 Fix regex compile assertion failure.
+- https://unicode-org.atlassian.net/browse/ICU-21492
+- https://github.com/unicode-org/icu/pull/1577
 
 ## ICU 68.2.0.2
 #### Changes cherry-picked from upstream tickets/PRs:

--- a/icu/icu4c/source/i18n/regexcmp.cpp
+++ b/icu/icu4c/source/i18n/regexcmp.cpp
@@ -3475,6 +3475,9 @@ int32_t   RegexCompile::minMatchLength(int32_t start, int32_t end) {
 //                     value may be longer than the actual maximum; it must
 //                     never be shorter.
 //
+//                     start, end: the range of the pattern to check.
+//                     end is inclusive.
+//
 //------------------------------------------------------------------------------
 int32_t   RegexCompile::maxMatchLength(int32_t start, int32_t end) {
     if (U_FAILURE(*fStatus)) {
@@ -3720,14 +3723,14 @@ int32_t   RegexCompile::maxMatchLength(int32_t start, int32_t end) {
                 // Look-behind.  Scan forward until the matching look-around end,
                 //   without processing the look-behind block.
                 int32_t dataLoc = URX_VAL(op);
-                for (loc = loc + 1; loc < end; ++loc) {
+                for (loc = loc + 1; loc <= end; ++loc) {
                     op = (int32_t)fRXPat->fCompiledPat->elementAti(loc);
                     int32_t opType = URX_TYPE(op);
                     if ((opType == URX_LA_END || opType == URX_LBN_END) && (URX_VAL(op) == dataLoc)) {
                         break;
                     }
                 }
-                U_ASSERT(loc < end);
+                U_ASSERT(loc <= end);
             }
             break;
 

--- a/icu/icu4c/source/test/testdata/regextst.txt
+++ b/icu/icu4c/source/test/testdata/regextst.txt
@@ -1497,6 +1497,11 @@
 #
 "(?w)\b"                     v2     "äää<0></0> äää"
 
+# Bug ICU-21492 Assertion failure with nested look-around expressions.
+#
+"(?<=(?:(?<=(?:(?<=(?:(?<=)){2})){3})){4}"   E  "<0></0>"  # orig failure from bug report, w mismatched parens.
+"(?:(?<=(?:(?<=)){2}))"            "<0></0>"               # Simplified case, with a valid pattern.
+
 #  Random debugging, Temporary
 #
 


### PR DESCRIPTION
## Summary
This change cherry-picks the upstream fix for the Regex assertion failure with nested look-behind blocks.

Upstream ticket:
https://unicode-org.atlassian.net/browse/ICU-21492

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
