### PR TITLE
Cherry-pick: ICU-21461 Fix cast of uprv_strcmp

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,10 @@ ICU-21461 uprops.h: remove unused gc macros
 - https://unicode-org.atlassian.net/browse/ICU-21461
 - https://github.com/unicode-org/icu/pull/1555
 
+ICU-21461 Fix cast of uprv_strcmp
+- https://unicode-org.atlassian.net/browse/ICU-21521
+- https://github.com/unicode-org/icu/pull/1618
+
 ## ICU 68.2.0.2
 #### Changes cherry-picked from upstream tickets/PRs:
 

--- a/icu/icu4c/source/common/locid.cpp
+++ b/icu/icu4c/source/common/locid.cpp
@@ -1453,8 +1453,12 @@ AliasReplacer::outputToString(
           out.append(SEP_CHAR, status);
         }
         variants.sort([](UElement e1, UElement e2) -> int8_t {
-            return uprv_strcmp(
+            // uprv_strcmp return int and in some platform, such as arm64-v8a,
+            // it may return positive values > 127 which cause the casted value
+            // of int8_t negative.
+            int res = uprv_strcmp(
                 (const char*)e1.pointer, (const char*)e2.pointer);
+            return (res == 0) ? 0 : ((res > 0) ? 1 : -1);
         }, status);
         int32_t variantsStart = out.length();
         for (int32_t i = 0; i < variants.size(); i++) {
@@ -1516,8 +1520,12 @@ AliasReplacer::replace(const Locale& locale, CharString& out, UErrorCode& status
 
     // Sort the variants
     variants.sort([](UElement e1, UElement e2) -> int8_t {
-        return uprv_strcmp(
+        // uprv_strcmp return int and in some platform, such as arm64-v8a,
+        // it may return positive values > 127 which cause the casted value
+        // of int8_t negative.
+        int res = uprv_strcmp(
             (const char*)e1.pointer, (const char*)e2.pointer);
+        return (res == 0) ? 0 : ((res > 0) ? 1 : -1);
     }, status);
 
     // A changed count to assert when loop too many times.


### PR DESCRIPTION
## Summary
`uprv_strcmp` is an alias for `strcmp`, which returns an `int`. On some platforms (such as aarch64 or arm64-v8a) it may return positive values that are larger than 127, which will cause the resulting value to be *negative* when cast to an `int8_t`.

Upstream ticket:
https://unicode-org.atlassian.net/browse/ICU-21521

Note: The upstream change modifies the file locid.cpp in 3 places. However, in the ICU v68.2 code the change is only needed in 2 places, as the `tfields` code was added in ICU v69.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
