### PR TITLE
Update changelog.md to add note about pre-built Linux ARM64 Nuget

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ## ICU 68.2.0.3
 #### General changes:
-- Picked up tzdata 2021a updates.
+- Add support for prebuilt Linux ARM64 binaries in the MS-ICU Nuget package. (#70)
+- Picked up tzdata 2021a updates. (#76)
 
 #### Changes cherry-picked from upstream tickets/PRs:
 


### PR DESCRIPTION
## Summary
This updates the changelog.md to add note about pre-built Linux ARM64 Nuget.
(I forgot to add this to the changelog when I did the work in the other PR).

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
