### PR TITLE
Fix ICU ticket number in changelog.md

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,7 @@ ICU-21461 uprops.h: remove unused gc macros
 - https://unicode-org.atlassian.net/browse/ICU-21461
 - https://github.com/unicode-org/icu/pull/1555
 
-ICU-21461 Fix cast of uprv_strcmp
+ICU-21521 Fix cast of uprv_strcmp
 - https://unicode-org.atlassian.net/browse/ICU-21521
 - https://github.com/unicode-org/icu/pull/1618
 


### PR DESCRIPTION
## Summary
The original change in PR #74 had the wrong ICU ticket number in the changelog.md, it should have been ticket `ICU-21521` instead.

Thanks to @daniel-ju for catching this!

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
