### PR TITLE
Cherry-pick: ICU-21537 Fix invalid free by long locale name

### DIFF
--- a/icu/icu4c/source/common/locid.cpp
+++ b/icu/icu4c/source/common/locid.cpp
@@ -254,7 +254,7 @@ UOBJECT_DEFINE_RTTI_IMPLEMENTATION(Locale)
 
 Locale::~Locale()
 {
-    if (baseName != fullName) {
+    if ((baseName != fullName) && (baseName != fullNameBuffer)) {
         uprv_free(baseName);
     }
     baseName = NULL;
@@ -466,7 +466,7 @@ Locale& Locale::operator=(const Locale& other) {
 }
 
 Locale& Locale::operator=(Locale&& other) U_NOEXCEPT {
-    if (baseName != fullName) uprv_free(baseName);
+    if ((baseName != fullName) && (baseName != fullNameBuffer)) uprv_free(baseName);
     if (fullName != fullNameBuffer) uprv_free(fullName);
 
     if (other.fullName == other.fullNameBuffer) {
@@ -1644,7 +1644,7 @@ Locale& Locale::init(const char* localeID, UBool canonicalize)
 {
     fIsBogus = FALSE;
     /* Free our current storage */
-    if (baseName != fullName) {
+    if ((baseName != fullName) && (baseName != fullNameBuffer)) {
         uprv_free(baseName);
     }
     baseName = NULL;
@@ -1680,6 +1680,7 @@ Locale& Locale::init(const char* localeID, UBool canonicalize)
             uloc_getName(localeID, fullName, sizeof(fullNameBuffer), &err);
 
         if(err == U_BUFFER_OVERFLOW_ERROR || length >= (int32_t)sizeof(fullNameBuffer)) {
+            U_ASSERT(baseName == nullptr);
             /*Go to heap for the fullName if necessary*/
             fullName = (char *)uprv_malloc(sizeof(char)*(length + 1));
             if(fullName == 0) {
@@ -1833,7 +1834,7 @@ Locale::hashCode() const
 void
 Locale::setToBogus() {
     /* Free our current storage */
-    if(baseName != fullName) {
+    if((baseName != fullName) && (baseName != fullNameBuffer)) {
         uprv_free(baseName);
     }
     baseName = NULL;

--- a/icu/icu4c/source/test/intltest/collationtest.cpp
+++ b/icu/icu4c/source/test/intltest/collationtest.cpp
@@ -78,6 +78,7 @@ public:
     void TestRootElements();
     void TestTailoredElements();
     void TestDataDriven();
+    void TestLongLocale();
 
 private:
     void checkFCD(const char *name, CollationIterator &ci, CodePointIterator &cpi);
@@ -148,6 +149,7 @@ void CollationTest::runIndexedTest(int32_t index, UBool exec, const char *&name,
     TESTCASE_AUTO(TestRootElements);
     TESTCASE_AUTO(TestTailoredElements);
     TESTCASE_AUTO(TestDataDriven);
+    TESTCASE_AUTO(TestLongLocale);
     TESTCASE_AUTO_END;
 }
 
@@ -1850,6 +1852,14 @@ void CollationTest::TestDataDriven() {
             return;
         }
     }
+}
+
+void CollationTest::TestLongLocale() {
+    IcuTestErrorCode errorCode(*this, "TestLongLocale");
+    Locale longLocale("sie__1G_C_CEIE_CEZCX_CSUE_E_EIESZNI2_GB_LM_LMCSUE_LMCSX_"
+                      "LVARIANT_MMCSIE_STEU_SU1GCEIE_SU6G_SU6SU6G_U_UBGE_UC_"
+                      "UCEZCSI_UCIE_UZSIU_VARIANT_X@collation=bcs-ukvsz");
+    LocalPointer<Collator> coll(Collator::createInstance(longLocale, errorCode));
 }
 
 #endif  // !UCONFIG_NO_COLLATION


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix, what does it change, how was it tested... -->
## Summary
This change cherry-picks an upstream fix for an invalid free of a long locale name.

Upstream ticket: https://unicode-org.atlassian.net/browse/ICU-21537
Upstream PR: https://github.com/unicode-org/icu/pull/1656

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
