### PR TITLE
Bump guava version to 30.0-jre

### DIFF
--- a/icu-patches/patches/016-MSFT-Patch-Bump_guava_version_to_30.0-jre.patch
+++ b/icu-patches/patches/016-MSFT-Patch-Bump_guava_version_to_30.0-jre.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Daniel Ju <41210545+daniel-ju@users.noreply.github.com>
+Date: Tue, 6 Apr 2021 17:53:03 -0700
+Subject: MSFT-PATCH: Bump guava version to 30.0-jre
+
+---
+ icu/tools/cldr/cldr-to-icu/pom.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/icu/tools/cldr/cldr-to-icu/pom.xml b/icu/tools/cldr/cldr-to-icu/pom.xml
+index 38a43e63fc..e8d72aa7f6 100644
+--- a/icu/tools/cldr/cldr-to-icu/pom.xml
++++ b/icu/tools/cldr/cldr-to-icu/pom.xml
+@@ -92,7 +92,7 @@
+         <dependency>
+             <groupId>com.google.guava</groupId>
+             <artifactId>guava</artifactId>
+-            <version>29.0-jre</version>
++            <version>30.0-jre</version>
+         </dependency>
+ 
+         <!-- Ant: Only used for running the conversion tool, not compiling it. -->
+-- 
+2.30.0.vfs.0.2
+

--- a/icu/tools/cldr/cldr-to-icu/pom.xml
+++ b/icu/tools/cldr/cldr-to-icu/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>30.0-jre</version>
         </dependency>
 
         <!-- Ant: Only used for running the conversion tool, not compiling it. -->


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix, what does it change, how was it tested... -->
## Summary
Bumped the guava version from 29.0-jre to 30.0-jre to pass the Component Governance task in the CI build.
Added a patch file as well in case this isn't updated in upstream ICU.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
