### PR TITLE
Bump version number to 68.2.0.5, and update changelog.md

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,17 @@
 # Changelog
 
+## ICU 68.2.0.5
+#### Data changes:
+- Add extra locales from CLDR-MS based on NLS "MS-Only" culture data. [#91](https://github.com/microsoft/icu/pull/91)
+- Update ff-Latn-MR region name. [#88](https://github.com/microsoft/icu/pull/88)
+
+#### Misc changes:
+- Update guava from 27.0-jre to 30.0-jre [#87](https://github.com/microsoft/icu/pull/87)
+
 ## ICU 68.2.0.4
 #### Data changes:
 - Update number grouping separator for French locales. [#80](https://github.com/microsoft/icu/pull/80)
 - Picked up additional tzdata fixes. [#81](https://github.com/microsoft/icu/pull/81)
-
 #### Changes cherry-picked from upstream tickets/PRs:
 
 ICU-21041 Fix fuzzer memory read error.

--- a/icu/icu4c/source/common/unicode/uvernum.h
+++ b/icu/icu4c/source/common/unicode/uvernum.h
@@ -79,7 +79,7 @@
  *  @stable ICU 4.0
  */
 #ifndef U_ICU_VERSION_BUILDLEVEL_NUM
-#define U_ICU_VERSION_BUILDLEVEL_NUM 4
+#define U_ICU_VERSION_BUILDLEVEL_NUM 5
 #endif
 
 /** Glued version suffix for renamers
@@ -139,7 +139,7 @@
  *  This value will change in the subsequent releases of ICU
  *  @stable ICU 2.4
  */
-#define U_ICU_VERSION "68.2.0.4"
+#define U_ICU_VERSION "68.2.0.5"
 
 /**
  * The current ICU library major version number as a string, for library name suffixes.

--- a/version.txt
+++ b/version.txt
@@ -35,5 +35,5 @@
 # in the header file "uvernum.h" whenever updated and/or changed.
 #
 
-ICU_version = 68.2.0.4
+ICU_version = 68.2.0.5
 ICU_upstream_hash = 84e1f26ea77152936e70d53178a816dbfbf69989


### PR DESCRIPTION
## Summary
This change bumps the version to 68.2.0.5, and updates the changelog.md file

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

