### PR TITLE
Bump version number to 68.2.0.6, and update changelog.md

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,13 @@
 # Changelog
+## ICU 68.2.0.6
+#### Misc changes:
+- Migration to ESRP Code Signing from PackageES Code Signing. [#93](https://github.com/microsoft/icu/pull/93)
+- Add Valgrind to CI build pipeline. [#95](https://github.com/microsoft/icu/pull/95)
+
+#### Changes cherry-picked from upstream tickets/PRs:
+ICU-21587 Fix memory bug w/ baseName
+- https://unicode-org.atlassian.net/browse/ICU-21587
+- https://github.com/unicode-org/icu/pull/1698
 
 ## ICU 68.2.0.5
 #### Data changes:

--- a/icu/icu4c/source/common/unicode/uvernum.h
+++ b/icu/icu4c/source/common/unicode/uvernum.h
@@ -79,7 +79,7 @@
  *  @stable ICU 4.0
  */
 #ifndef U_ICU_VERSION_BUILDLEVEL_NUM
-#define U_ICU_VERSION_BUILDLEVEL_NUM 5
+#define U_ICU_VERSION_BUILDLEVEL_NUM 6
 #endif
 
 /** Glued version suffix for renamers
@@ -139,7 +139,7 @@
  *  This value will change in the subsequent releases of ICU
  *  @stable ICU 2.4
  */
-#define U_ICU_VERSION "68.2.0.5"
+#define U_ICU_VERSION "68.2.0.6"
 
 /**
  * The current ICU library major version number as a string, for library name suffixes.

--- a/version.txt
+++ b/version.txt
@@ -35,5 +35,5 @@
 # in the header file "uvernum.h" whenever updated and/or changed.
 #
 
-ICU_version = 68.2.0.5
+ICU_version = 68.2.0.6
 ICU_upstream_hash = 84e1f26ea77152936e70d53178a816dbfbf69989


### PR DESCRIPTION
## Summary
This change bumps the version to 68.2.0.6, and updates the `changelog.md` file

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
