### PR TITLE
Fix Windows symbols publishing in the Nuget pipeline.

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -451,8 +451,7 @@ stages:
   - CreateNuget
   condition: and(eq(variables.codeSign, true), and(in(dependencies.CodeSignBinaries.result, 'Succeeded'), in(dependencies.CreateNuget.result, 'Succeeded')))
   pool:
-    name: Azure Pipelines
-    vmImage: 'windows-2019'
+    name: Package ES CodeHub Lab E
   variables:
     BuildPlatform: AnyCPU
 

--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -416,25 +416,6 @@ stages:
         artifactName: 'linux-arm64'
         downloadPath: '$(Build.BINARIESDIRECTORY)\bits'
 
-    # Symbols (PDBs)
-    - task: DownloadBuildArtifacts@0
-      displayName: 'Download symbols-win-x86'
-      inputs:
-        artifactName: 'symbols-win-x86'
-        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
-
-    - task: DownloadBuildArtifacts@0
-      displayName: 'Download symbols-win-x64'
-      inputs:
-        artifactName: 'symbols-win-x64'
-        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
-
-    - task: DownloadBuildArtifacts@0
-      displayName: 'Download symbols-win-ARM64'
-      inputs:
-        artifactName: 'symbols-win-ARM64'
-        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
-
     - powershell: |
         Write-Host ""
         Write-Host "$(BUILD.BINARIESDIRECTORY)"
@@ -554,6 +535,31 @@ stages:
       inputs:
         PathtoPublish: '$(BUILD.ArtifactStagingDirectory)\nuget\Nuget_Packages'
         ArtifactName: 'Nuget_Packages_Signed'
+
+    # Symbols (PDBs)
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download symbols-win-x86'
+      inputs:
+        artifactName: 'symbols-win-x86'
+        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
+
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download symbols-win-x64'
+      inputs:
+        artifactName: 'symbols-win-x64'
+        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
+
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download symbols-win-ARM64'
+      inputs:
+        artifactName: 'symbols-win-ARM64'
+        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
+    
+    - powershell: |
+        Write-Host ""
+        Write-Host "$(BUILD.BINARIESDIRECTORY)"
+        Tree /F /A $(BUILD.BINARIESDIRECTORY)
+      displayName: 'DIAG: dir'
 
     # Publish the Windows Symbols to the public symbols server
     - task: PublishSymbols@2


### PR DESCRIPTION
## Summary
Since the Nuget creation and Nuget code signing are now done as two separate stages in the build pipeline, the Windows symbols publishing task fails as it relied on the `DownloadBuildArtifacts` tasks in the Nuget creation step. (This was missed in the refactoring of the pipeline in PR #93.)
However, since the Nuget doesn't contain any symbols at all, we can move the `DownloadBuildArtifacts` tasks entirely to the Nuget code signing stage instead.

Also, it turns out that the `PublishSymbols` task cannot run on the public Azure Pipelines pool and must be run on the PackageES pool. (Note: I skipped the actual publish step when testing PR #93, as you can't unpublish things once published. However, when running the Release Pipeline to publish for real, it errors out.)
Note: FWIW, the ProjectReunion pipeline also uses the PackageES lab for publishing symbols as well here:
https://github.com/microsoft/ProjectReunion/blob/1714557cad5e740c0153e451fbf0311c8e5bdfc1/build/ProjectReunion-BuildFoundation.yml#L172-L188

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
