### PR TITLE
Update maint/maint-68 for fix for Windows symbols publishing

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -416,25 +416,6 @@ stages:
         artifactName: 'linux-arm64'
         downloadPath: '$(Build.BINARIESDIRECTORY)\bits'
 
-    # Symbols (PDBs)
-    - task: DownloadBuildArtifacts@0
-      displayName: 'Download symbols-win-x86'
-      inputs:
-        artifactName: 'symbols-win-x86'
-        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
-
-    - task: DownloadBuildArtifacts@0
-      displayName: 'Download symbols-win-x64'
-      inputs:
-        artifactName: 'symbols-win-x64'
-        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
-
-    - task: DownloadBuildArtifacts@0
-      displayName: 'Download symbols-win-ARM64'
-      inputs:
-        artifactName: 'symbols-win-ARM64'
-        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
-
     - powershell: |
         Write-Host ""
         Write-Host "$(BUILD.BINARIESDIRECTORY)"
@@ -470,8 +451,7 @@ stages:
   - CreateNuget
   condition: and(eq(variables.codeSign, true), and(in(dependencies.CodeSignBinaries.result, 'Succeeded'), in(dependencies.CreateNuget.result, 'Succeeded')))
   pool:
-    name: Azure Pipelines
-    vmImage: 'windows-2019'
+    name: Package ES CodeHub Lab E
   variables:
     BuildPlatform: AnyCPU
 
@@ -554,6 +534,31 @@ stages:
       inputs:
         PathtoPublish: '$(BUILD.ArtifactStagingDirectory)\nuget\Nuget_Packages'
         ArtifactName: 'Nuget_Packages_Signed'
+
+    # Symbols (PDBs)
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download symbols-win-x86'
+      inputs:
+        artifactName: 'symbols-win-x86'
+        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
+
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download symbols-win-x64'
+      inputs:
+        artifactName: 'symbols-win-x64'
+        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
+
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download symbols-win-ARM64'
+      inputs:
+        artifactName: 'symbols-win-ARM64'
+        downloadPath: '$(Build.BINARIESDIRECTORY)\symbols'
+    
+    - powershell: |
+        Write-Host ""
+        Write-Host "$(BUILD.BINARIESDIRECTORY)"
+        Tree /F /A $(BUILD.BINARIESDIRECTORY)
+      displayName: 'DIAG: dir'
 
     # Publish the Windows Symbols to the public symbols server
     - task: PublishSymbols@2


### PR DESCRIPTION
## Summary
This merges the master branch to maint/maint-68 in order to pick up the fix for Windows symbols publishing (PR #98).
(This will be done as a merge commit to keep the history).

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
