### PR TITLE
Add South Sudan (Juba) to Windows time zone mapping

### DIFF
--- a/icu/icu4c/source/data/misc/windowsZones.txt
+++ b/icu/icu4c/source/data/misc/windowsZones.txt
@@ -609,12 +609,15 @@ windowsZones:table(nofallback){
             MW{"Africa/Blantyre"}
             MZ{"Africa/Maputo"}
             RW{"Africa/Kigali"}
-            SS{"Africa/Juba"}
             SZ{"Africa/Mbabane"}
             ZA{"Africa/Johannesburg"}
             ZM{"Africa/Lusaka"}
             ZW{"Africa/Harare"}
             ZZ{"Etc/GMT-2"}
+        }
+        "South Sudan Standard Time"{
+            001{"Africa/Juba"}
+            SS{"Africa/Juba"}
         }
         "Sri Lanka Standard Time"{
             001{"Asia/Colombo"}


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix, what does it change, how was it tested... -->
## Summary
This updates the `windowsZones.txt` data file after cherry-picking the upstream CLDR changes to `windowsZones.xml` from here:

Upstream PR: https://github.com/unicode-org/cldr/pull/1193
CLDR ticket: https://unicode-org.atlassian.net/browse/CLDR-14653

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
