### PR TITLE
Port work-around for Ubuntu 18.04 Azure CI built bot breaking builds

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -11,6 +11,11 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 1
+    # This is to work-around issue: https://github.com/actions/virtual-environments/issues/3376
+    # Once the Ubuntu 18.04 build bot image is fixed, we can remove this work-around.
+    - script: |
+        sudo apt remove libgcc-11-dev gcc-11
+      displayName: Remove GCC 11 (work-around)
     - task: PowerShell@2
       displayName: 'Set ICU Version'
       inputs:
@@ -111,6 +116,11 @@ jobs:
     - checkout: self
       lfs: true
       fetchDepth: 1
+    # This is to work-around issue: https://github.com/actions/virtual-environments/issues/3376
+    # Once the Ubuntu 18.04 build bot image is fixed, we can remove this work-around.
+    - script: |
+        sudo apt remove libgcc-11-dev gcc-11
+      displayName: Remove GCC 11 (work-around)
     - task: PowerShell@2
       displayName: 'Set ICU Version'
       inputs:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix, what does it change, how was it tested... -->
## Summary
This ports Jeff's fix from upstream ICU to work-around the Ubuntu 18.04 build bots from breaking the build pipelines when running the ICU tests.

Upstream fix: https://github.com/unicode-org/icu/pull/1723

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
