### PR TITLE
Fix crash if ICU default locale has BCP47 extensions. Fix ures_openDirect crash with NULL locale.

### DIFF
--- a/icu-patches/patches/019-ICU-Patch-ICU-21705_Fix_ures_openDirect_crash_with_NULL_localeID.patch
+++ b/icu-patches/patches/019-ICU-Patch-ICU-21705_Fix_ures_openDirect_crash_with_NULL_localeID.patch
@@ -1,0 +1,113 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeff Genovy <29107334+jefgen@users.noreply.github.com>
+Date: Tue, 10 Aug 2021 12:43:52 -0700
+Subject: ICU-21705 ICU-21706 Fix crash if ICU's default locale has BCP47
+ Unicode Extensions, and fix ures_openDirect crash with NULL locale ID.
+
+Add test case for ures_openDirect with NULL locale ID.
+
+diff --git a/icu/icu4c/source/common/uresbund.cpp b/icu/icu4c/source/common/uresbund.cpp
+index f17ba1be895b828a0b63d1e043c674031db11643..e92edec029afd6a7f1e17eed95aa4d8bbdd813d9 100644
+--- a/icu/icu4c/source/common/uresbund.cpp
++++ b/icu/icu4c/source/common/uresbund.cpp
+@@ -452,11 +452,10 @@ getPoolEntry(const char *path, UErrorCode *status) {
+ /* INTERNAL: */
+ /*   CAUTION:  resbMutex must be locked when calling this function! */
+ static UResourceDataEntry *
+-findFirstExisting(const char* path, char* name,
++findFirstExisting(const char* path, char* name, const char* defaultLocale,
+                   UBool *isRoot, UBool *hasChopped, UBool *isDefault, UErrorCode* status) {
+     UResourceDataEntry *r = NULL;
+     UBool hasRealData = FALSE;
+-    const char *defaultLoc = uloc_getDefault();
+     *hasChopped = TRUE; /* we're starting with a fresh name */
+ 
+     while(*hasChopped && !hasRealData) {
+@@ -465,7 +464,7 @@ findFirstExisting(const char* path, char* name,
+         if (U_FAILURE(*status)) {
+             return NULL;
+         }
+-        *isDefault = (UBool)(uprv_strncmp(name, defaultLoc, uprv_strlen(name)) == 0);
++        *isDefault = (UBool)(uprv_strncmp(name, defaultLocale, uprv_strlen(name)) == 0);
+         hasRealData = (UBool)(r->fBogus == U_ZERO_ERROR);
+         if(!hasRealData) {
+             /* this entry is not real. We will discard it. */
+@@ -660,10 +659,13 @@ static UResourceDataEntry *entryOpen(const char* path, const char* localeID,
+         }
+     }
+  
++    // Note: We need to query the default locale *before* locking resbMutex.
++    const char *defaultLocale = uloc_getDefault();
++
+     Mutex lock(&resbMutex);    // Lock resbMutex until the end of this function.
+ 
+     /* We're going to skip all the locales that do not have any data */
+-    r = findFirstExisting(path, name, &isRoot, &hasChopped, &isDefault, &intStatus);
++    r = findFirstExisting(path, name, defaultLocale, &isRoot, &hasChopped, &isDefault, &intStatus);
+ 
+     // If we failed due to out-of-memory, report the failure and exit early.
+     if (intStatus == U_MEMORY_ALLOCATION_ERROR) {
+@@ -703,8 +705,8 @@ static UResourceDataEntry *entryOpen(const char* path, const char* localeID,
+     /* if that is the case, we need to chain in the default locale   */
+     if(r==NULL && openType == URES_OPEN_LOCALE_DEFAULT_ROOT && !isDefault && !isRoot) {
+         /* insert default locale */
+-        uprv_strcpy(name, uloc_getDefault());
+-        r = findFirstExisting(path, name, &isRoot, &hasChopped, &isDefault, &intStatus);
++        uprv_strcpy(name, defaultLocale);
++        r = findFirstExisting(path, name, defaultLocale, &isRoot, &hasChopped, &isDefault, &intStatus);
+         // If we failed due to out-of-memory, report the failure and exit early.
+         if (intStatus == U_MEMORY_ALLOCATION_ERROR) {
+             *status = intStatus;
+@@ -728,7 +730,7 @@ static UResourceDataEntry *entryOpen(const char* path, const char* localeID,
+     /* present */
+     if(r == NULL) {
+         uprv_strcpy(name, kRootLocaleName);
+-        r = findFirstExisting(path, name, &isRoot, &hasChopped, &isDefault, &intStatus);
++        r = findFirstExisting(path, name, defaultLocale, &isRoot, &hasChopped, &isDefault, &intStatus);
+         // If we failed due to out-of-memory, report the failure and exit early.
+         if (intStatus == U_MEMORY_ALLOCATION_ERROR) {
+             *status = intStatus;
+@@ -782,7 +784,17 @@ entryOpenDirect(const char* path, const char* localeID, UErrorCode* status) {
+         return NULL;
+     }
+ 
++    // Note: We need to query the default locale *before* locking resbMutex.
++    // If the localeID is NULL, then we want to use the default locale.
++    if (localeID == NULL) {
++        localeID = uloc_getDefault();
++    } else if (*localeID == 0) {
++        // If the localeID is "", then we want to use the root locale.
++        localeID = kRootLocaleName;
++    }
++
+     Mutex lock(&resbMutex);
++
+     // findFirstExisting() without fallbacks.
+     UResourceDataEntry *r = init_entry(localeID, path, status);
+     if(U_SUCCESS(*status)) {
+diff --git a/icu/icu4c/source/test/cintltst/crestst.c b/icu/icu4c/source/test/cintltst/crestst.c
+index 080301090d1db53457acaf9476b78b6ccb152aab..4eb77b0893245cf33eb0e50872fa4d206da3d309 100644
+--- a/icu/icu4c/source/test/cintltst/crestst.c
++++ b/icu/icu4c/source/test/cintltst/crestst.c
+@@ -496,7 +496,7 @@ static void TestFallback()
+ 
+ static void
+ TestOpenDirect(void) {
+-    UResourceBundle *idna_rules, *casing, *te_IN, *ne, *item;
++    UResourceBundle *idna_rules, *casing, *te_IN, *ne, *item, *defaultLocale;
+     UErrorCode errorCode;
+ 
+     /*
+@@ -641,6 +641,12 @@ TestOpenDirect(void) {
+         ures_close(item);
+     }
+     ures_close(te_IN);
++
++    // ICU-21705
++    // Verify that calling ures_openDirect() with NULL localeID doesn't crash or assert.
++    errorCode = U_ZERO_ERROR;
++    defaultLocale = ures_openDirect(NULL, NULL, &errorCode);
++    ures_close(defaultLocale);
+ }
+ 
+ static void

--- a/icu/icu4c/source/common/uresbund.cpp
+++ b/icu/icu4c/source/common/uresbund.cpp
@@ -452,11 +452,10 @@ getPoolEntry(const char *path, UErrorCode *status) {
 /* INTERNAL: */
 /*   CAUTION:  resbMutex must be locked when calling this function! */
 static UResourceDataEntry *
-findFirstExisting(const char* path, char* name,
+findFirstExisting(const char* path, char* name, const char* defaultLocale,
                   UBool *isRoot, UBool *hasChopped, UBool *isDefault, UErrorCode* status) {
     UResourceDataEntry *r = NULL;
     UBool hasRealData = FALSE;
-    const char *defaultLoc = uloc_getDefault();
     *hasChopped = TRUE; /* we're starting with a fresh name */
 
     while(*hasChopped && !hasRealData) {
@@ -465,7 +464,7 @@ findFirstExisting(const char* path, char* name,
         if (U_FAILURE(*status)) {
             return NULL;
         }
-        *isDefault = (UBool)(uprv_strncmp(name, defaultLoc, uprv_strlen(name)) == 0);
+        *isDefault = (UBool)(uprv_strncmp(name, defaultLocale, uprv_strlen(name)) == 0);
         hasRealData = (UBool)(r->fBogus == U_ZERO_ERROR);
         if(!hasRealData) {
             /* this entry is not real. We will discard it. */
@@ -660,10 +659,13 @@ static UResourceDataEntry *entryOpen(const char* path, const char* localeID,
         }
     }
  
+    // Note: We need to query the default locale *before* locking resbMutex.
+    const char *defaultLocale = uloc_getDefault();
+
     Mutex lock(&resbMutex);    // Lock resbMutex until the end of this function.
 
     /* We're going to skip all the locales that do not have any data */
-    r = findFirstExisting(path, name, &isRoot, &hasChopped, &isDefault, &intStatus);
+    r = findFirstExisting(path, name, defaultLocale, &isRoot, &hasChopped, &isDefault, &intStatus);
 
     // If we failed due to out-of-memory, report the failure and exit early.
     if (intStatus == U_MEMORY_ALLOCATION_ERROR) {
@@ -703,8 +705,8 @@ static UResourceDataEntry *entryOpen(const char* path, const char* localeID,
     /* if that is the case, we need to chain in the default locale   */
     if(r==NULL && openType == URES_OPEN_LOCALE_DEFAULT_ROOT && !isDefault && !isRoot) {
         /* insert default locale */
-        uprv_strcpy(name, uloc_getDefault());
-        r = findFirstExisting(path, name, &isRoot, &hasChopped, &isDefault, &intStatus);
+        uprv_strcpy(name, defaultLocale);
+        r = findFirstExisting(path, name, defaultLocale, &isRoot, &hasChopped, &isDefault, &intStatus);
         // If we failed due to out-of-memory, report the failure and exit early.
         if (intStatus == U_MEMORY_ALLOCATION_ERROR) {
             *status = intStatus;
@@ -728,7 +730,7 @@ static UResourceDataEntry *entryOpen(const char* path, const char* localeID,
     /* present */
     if(r == NULL) {
         uprv_strcpy(name, kRootLocaleName);
-        r = findFirstExisting(path, name, &isRoot, &hasChopped, &isDefault, &intStatus);
+        r = findFirstExisting(path, name, defaultLocale, &isRoot, &hasChopped, &isDefault, &intStatus);
         // If we failed due to out-of-memory, report the failure and exit early.
         if (intStatus == U_MEMORY_ALLOCATION_ERROR) {
             *status = intStatus;
@@ -782,7 +784,17 @@ entryOpenDirect(const char* path, const char* localeID, UErrorCode* status) {
         return NULL;
     }
 
+    // Note: We need to query the default locale *before* locking resbMutex.
+    // If the localeID is NULL, then we want to use the default locale.
+    if (localeID == NULL) {
+        localeID = uloc_getDefault();
+    } else if (*localeID == 0) {
+        // If the localeID is "", then we want to use the root locale.
+        localeID = kRootLocaleName;
+    }
+
     Mutex lock(&resbMutex);
+
     // findFirstExisting() without fallbacks.
     UResourceDataEntry *r = init_entry(localeID, path, status);
     if(U_SUCCESS(*status)) {

--- a/icu/icu4c/source/test/cintltst/crestst.c
+++ b/icu/icu4c/source/test/cintltst/crestst.c
@@ -496,7 +496,7 @@ static void TestFallback()
 
 static void
 TestOpenDirect(void) {
-    UResourceBundle *idna_rules, *casing, *te_IN, *ne, *item;
+    UResourceBundle *idna_rules, *casing, *te_IN, *ne, *item, *defaultLocale;
     UErrorCode errorCode;
 
     /*
@@ -641,6 +641,12 @@ TestOpenDirect(void) {
         ures_close(item);
     }
     ures_close(te_IN);
+
+    // ICU-21705
+    // Verify that calling ures_openDirect() with NULL localeID doesn't crash or assert.
+    errorCode = U_ZERO_ERROR;
+    defaultLocale = ures_openDirect(NULL, NULL, &errorCode);
+    ures_close(defaultLocale);
 }
 
 static void


### PR DESCRIPTION
## Summary
This PR fixes two issues:
- Fix crash if ICU's default locale has BCP47 Unicode Extensions.
- Fix `ures_openDirect` crash with a NULL input locale ID.

It also adds a test case for `ures_openDirect` with a NULL input locale ID.

This change adds a new ICU-PATCH file for the changes, though hopefully this won't be needed and we can fix this issue upstream before ingesting a new version of ICU.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
  *  **Note:** I've filed upstream tickets for these two issues and will be making a PR for them later.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

## Detailed Description

#### ICU-21705 Calling ures_openDirect with NULL locale ID results in crash (undefined behavior)

Calling the public API `ures_openDirect` will crash if you call it with a `NULL` Locale ID -- even though this is permitted by the API docs.

The issue is that `strcmp` is called with the input locale ID (ie: null pointer), which is undefined behavior, and causes the crash.

This doesn't occur with `ures_open`, as that calls `uloc_getBaseName()` first, which gets the default locale via `_canonicalize()`, so that the call to `strcmp` has a locale ID (rather than a null pointer).

We need to check the input locale ID and adjust it accordingly if it is null (default locale) or a pointer to empty string (root locale). 

#### ICU-21706 ICU4C test suite crashes if the default locale has any BCP47 Unicode extension tags on it (ex: "en-US-u-hc-12")

If ICU's default locale has any BCP47 Unicode extension tags on it (ex: "en-US-u-hc-12") then the ICU test suite will crash.

The problem is that the `resbMutex` is attempted to be locked twice, which leads to the crash/termination.

The issue occurs on the first call to `ures_open()`. This causes the ICU data file to be loaded. However, the default locale isn't yet cached in `gDefaultLocale`, so `Locale::getDefault` needs to query the host OS for the default locale.

If the default locale has any BCP47 Unicode extension tags, this causes `_canonicalize` to attempt to convert them to the legacy ICU style extensions by calling `uloc_forLanguageTag`. As part of this conversion, `uloc_toLegacyKey` will also attempt to load the ICU data file, in order to load the `keyTypeData` to map the extensions.

However, this is problematic, as it means that we're now trying to load the data file while trying to load the data file. In other words, it means that the `resbMutex` will attempted to be locked twice – leading to the crash.

However, we can avoid this by moving the query for the default locale to be outside of the mutex protected part of the code – which allows us to avoid the circular nature of the issue. We can query and store the ICU default locale, and then pass it to the `findFirstExisting` function inside the mutex protected part of the code, so it doesn’t need to query for the default locale itself.
