### PR TITLE
Migrate from PackageES build agents to public Microsoft hosted Azure agents

### DIFF
--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -451,7 +451,8 @@ stages:
   - CreateNuget
   condition: and(eq(variables.codeSign, true), and(in(dependencies.CodeSignBinaries.result, 'Succeeded'), in(dependencies.CreateNuget.result, 'Succeeded')))
   pool:
-    name: Package ES CodeHub Lab E
+    name: Azure Pipelines
+    vmImage: 'windows-2019'
   variables:
     BuildPlatform: AnyCPU
 
@@ -561,17 +562,17 @@ stages:
       displayName: 'DIAG: dir'
 
     # Publish the Windows Symbols to the public symbols server
-    - task: PublishSymbols@2
-      displayName: 'Publish Windows Symbols'
-      inputs:
-        symbolsFolder: '$(Build.BINARIESDIRECTORY)\symbols'
-        searchPattern: '**/*.pdb'
-        IndexSources: false
-        SymbolsMaximumWaitTime: 30
-        SymbolServerType: 'TeamServices'
-        SymbolsProduct: 'MS-ICU Nuget Windows binaries'
-        SymbolsVersion: '$(ICUVersion)'
-      condition: and(succeeded(), eq(variables.codeSign, true))
-      env:
-        ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
-        ArtifactServices_Symbol_UseAAD: true
+    # - task: PublishSymbols@2
+    #   displayName: 'Publish Windows Symbols'
+    #   inputs:
+    #     symbolsFolder: '$(Build.BINARIESDIRECTORY)\symbols'
+    #     searchPattern: '**/*.pdb'
+    #     IndexSources: false
+    #     SymbolsMaximumWaitTime: 30
+    #     SymbolServerType: 'TeamServices'
+    #     SymbolsProduct: 'MS-ICU Nuget Windows binaries'
+    #     SymbolsVersion: '$(ICUVersion)'
+    #   condition: and(succeeded(), eq(variables.codeSign, true))
+    #   env:
+    #     ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
+    #     ArtifactServices_Symbol_UseAAD: true

--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -561,7 +561,8 @@ stages:
         Tree /F /A $(BUILD.BINARIESDIRECTORY)
       displayName: 'DIAG: dir'
 
-    # Publish the Windows Symbols to the internal and public symbols servers.
+    # Publish the Windows Symbols to the MSCodeHub internal symbol server.
+    # Accessible via https://mscodehub.artifacts.visualstudio.com/_apis/symbol/symsrv
     - task: PublishSymbols@2
       displayName: 'Publish symbols to internal server (no source indexing)'
       inputs:
@@ -579,6 +580,8 @@ stages:
       env:
         LIB: $(Build.SourcesDirectory)
 
+    # Publish the Windows Symbols to the public MSDL symbol server.
+    # Accessible via https://msdl.microsoft.com/download/symbols
     - task: PublishSymbols@2
       displayName: 'Publish symbols to public server (no source indexing)'
       inputs:

--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -562,17 +562,17 @@ stages:
       displayName: 'DIAG: dir'
 
     # Publish the Windows Symbols to the public symbols server
-    # - task: PublishSymbols@2
-    #   displayName: 'Publish Windows Symbols'
-    #   inputs:
-    #     symbolsFolder: '$(Build.BINARIESDIRECTORY)\symbols'
-    #     searchPattern: '**/*.pdb'
-    #     IndexSources: false
-    #     SymbolsMaximumWaitTime: 30
-    #     SymbolServerType: 'TeamServices'
-    #     SymbolsProduct: 'MS-ICU Nuget Windows binaries'
-    #     SymbolsVersion: '$(ICUVersion)'
-    #   condition: and(succeeded(), eq(variables.codeSign, true))
-    #   env:
-    #     ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
-    #     ArtifactServices_Symbol_UseAAD: true
+    - task: PublishSymbols@2
+      displayName: 'Publish Windows Symbols'
+      inputs:
+        symbolsFolder: '$(Build.BINARIESDIRECTORY)\symbols'
+        searchPattern: '**/*.pdb'
+        IndexSources: false
+        SymbolsMaximumWaitTime: 30
+        SymbolServerType: 'TeamServices'
+        SymbolsProduct: 'MS-ICU Nuget Windows binaries'
+        SymbolsVersion: '$(ICUVersion)'
+      condition: and(succeeded(), eq(variables.codeSign, true))
+      env:
+        ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
+        ArtifactServices_Symbol_UseAAD: true

--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -561,18 +561,39 @@ stages:
         Tree /F /A $(BUILD.BINARIESDIRECTORY)
       displayName: 'DIAG: dir'
 
-    # Publish the Windows Symbols to the public symbols server
+    # Publish the Windows Symbols to the internal and public symbols servers.
     - task: PublishSymbols@2
-      displayName: 'Publish Windows Symbols'
+      displayName: 'Publish symbols to internal server (no source indexing)'
       inputs:
         symbolsFolder: '$(Build.BINARIESDIRECTORY)\symbols'
         searchPattern: '**/*.pdb'
-        IndexSources: false
         SymbolsMaximumWaitTime: 30
         SymbolServerType: 'TeamServices'
         SymbolsProduct: 'MS-ICU Nuget Windows binaries'
         SymbolsVersion: '$(ICUVersion)'
-      condition: and(succeeded(), eq(variables.codeSign, true))
+      # The ADO task does not support indexing of GitHub sources.
+        indexSources: false
+        detailedLog: true
+      # There is a bug which causes this task to fail if LIB includes an inaccessible path (even though it does not depend on it).
+      # To work around this issue, we just force LIB to be any dir that we know exists.
       env:
+        LIB: $(Build.SourcesDirectory)
+
+    - task: PublishSymbols@2
+      displayName: 'Publish symbols to public server (no source indexing)'
+      inputs:
+        symbolsFolder: '$(Build.BINARIESDIRECTORY)\symbols'
+        searchPattern: '**/*.pdb'
+        SymbolsMaximumWaitTime: 30
+        SymbolServerType: 'TeamServices'
+        SymbolsProduct: 'MS-ICU Nuget Windows binaries'
+        SymbolsVersion: '$(ICUVersion)'
+      # The ADO task does not support indexing of GitHub sources.
+        indexSources: false
+        detailedLog: true
+      # There is a bug which causes this task to fail if LIB includes an inaccessible path (even though it does not depend on it).
+      # To work around this issue, we just force LIB to be any dir that we know exists.
+      env:
+        LIB: $(Build.SourcesDirectory)
         ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
-        ArtifactServices_Symbol_UseAAD: true
+        ArtifactServices_Symbol_PAT: $(MSICU_microsoftpublicsymbols_PAT)

--- a/build/azure-nuget.yml
+++ b/build/azure-nuget.yml
@@ -561,25 +561,6 @@ stages:
         Tree /F /A $(BUILD.BINARIESDIRECTORY)
       displayName: 'DIAG: dir'
 
-    # Publish the Windows Symbols to the MSCodeHub internal symbol server.
-    # Accessible via https://mscodehub.artifacts.visualstudio.com/_apis/symbol/symsrv
-    - task: PublishSymbols@2
-      displayName: 'Publish symbols to internal server (no source indexing)'
-      inputs:
-        symbolsFolder: '$(Build.BINARIESDIRECTORY)\symbols'
-        searchPattern: '**/*.pdb'
-        SymbolsMaximumWaitTime: 30
-        SymbolServerType: 'TeamServices'
-        SymbolsProduct: 'MS-ICU Nuget Windows binaries'
-        SymbolsVersion: '$(ICUVersion)'
-      # The ADO task does not support indexing of GitHub sources.
-        indexSources: false
-        detailedLog: true
-      # There is a bug which causes this task to fail if LIB includes an inaccessible path (even though it does not depend on it).
-      # To work around this issue, we just force LIB to be any dir that we know exists.
-      env:
-        LIB: $(Build.SourcesDirectory)
-
     # Publish the Windows Symbols to the public MSDL symbol server.
     # Accessible via https://msdl.microsoft.com/download/symbols
     - task: PublishSymbols@2


### PR DESCRIPTION
## Summary
This PR updates the build pool used for building the MS-ICU Nuget to migrate off the PackageES build agents and uses the public Microsoft hosted Azure DevOps build agents instead.

It also changes the publishing of the symbols for the MS-ICU Nuget, so that we can continue to have symbols available via the public MSDL symbol server.

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

## Detailed Description

The Package ES build agents are being deprecated, and will stop working after Sept 30th. This means that we need to move off of the `Package ES CodeHub Lab E` pool and find another pool to run our builds on.

Originally, I thought that we'd need to migrate to a custom hosted pool (using the 1ES Hosted Pool to run custom agents), but after doing some investigating, it turns out that we can actually run on the public Microsoft hosted Azure DevOps build agents instead.

This means that we don't need to setup and run our own custom pool in an Azure subscription. 😊

Additionally, we can also continue to publish the Windows symbols for the MS-ICU Nuget to the public MSDL symbol server, by making some changes to how things are published.

Instead of using the AAD authentication to publish, we can switch to using a secure variable for a PAT token via the TARGET Dev Bot (@targetdev-bot) in order to publish the symbols. This variable is only accessible to the *manually* triggered "Release-Nuget" pipeline, so that other pipelines cannot access it.

So the symbols will still be available from the public MSDL symbol server:
https://msdl.microsoft.com/download/symbols
