### PR TITLE
Add missing entries to changelog.md for v68.2.0.9

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 ## ICU 68.2.0.9
 #### Misc changes:
 - Migrate from PackageES build agents to public Microsoft hosted agents [#113](https://github.com/microsoft/icu/pull/113)
+- Fix crash if ICU default locale has BCP47 extensions. Fix ures_openDirect crash with NULL locale. [#110](https://github.com/microsoft/icu/pull/110)
+- Fix LocaleBuilder errors when ICU default locale has BCP47 Unicode extension tags. [#111](https://github.com/microsoft/icu/pull/111)
 
 ## ICU 68.2.0.8
 #### Data changes:


### PR DESCRIPTION
## Summary
When double-checking the content in `maint/maint-68`, I realized that I missed adding these entries to the `changelog.md` for `v68.2.0.9` in PR #114.

(FWIW, if you want to double-check, you can see the content here: https://github.com/microsoft/icu/pull/115/commits)

## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.
