### PR TITLE
Create patch file for recently merged preferences override library

### DIFF
--- a/icu-patches/patches/020-MSFT-Patch_ICU_Add_uprefs_library_to_obtain_default_locale_as_full_BCP47_tag.patch
+++ b/icu-patches/patches/020-MSFT-Patch_ICU_Add_uprefs_library_to_obtain_default_locale_as_full_BCP47_tag.patch
@@ -1,100 +1,15 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Erik Torres <erik.torres.aguilar@gmail.com>
+From: Erik Torres <26077674+erik0686@users.noreply.github.com>
 Date: Wed, 6 Oct 2021 15:06:30 -0700
 Subject: Add uprefs library to ICU to obtain the default locale as a full
  BCP47 tag (#112)
 
-* port library to work with ICU
+Currently, for many processes and tasks, ICU gets the default locale and caches it. This means that when needed, ICU will get something like "en-US" and that will not change even if you were to change your language or region in your device.
+Furthermore, ICU has currently no way of getting other globalization settings such as currency, calendar, hour cycle, first day of week, sorting method and measurement system.
+We have decided to add a way to solve these two problems.
+By adding the uprefs library (only to the Windows implementation of uprv_getDefaultLocaleID()), we are adding the Uprefs_getBCP47Tag() internal API, which obtains a full, canonical and valid BCP47Tag containing all of the settings.
 
-clean and update
-
-fix leaks
-
-remove caching and unneeded code
-
-handle memoryu allocation error
-
-change to uprv malloc
-
-change method usage
-
-change UChar to char
-
-use CharStrings and remove unused apis
-
-address feedback
-
-address feedback
-
-fix mistakes
-
-fix mistakes
-
-fix mistakes
-
-fix mistakes
-
-fix mistakes
-
-debugging
-
-return calendar that was failing
-
-address feedback and add calendar
-
-remove unneeded method
-
-create RAII objects for wchar t
-
-add tests for library
-
-test only on windows
-
-address feedback
-
-fix casting failures
-
-remove two check pattern and fix tests
-
-fix tests
-
-fix ci builds
-
-fix ci builds
-
-address feedback
-
-address feedback
-
-fix quotes I missed
-
-use char instead of strings
-
-add test file to objects
-
-fix typo sigh...
-
-add fork for previous behaviour and add test
-
-fix name of test
-
-Add variable to uconfig
-
-improve test case
-
-* address feedback
-
-* address feedback again
-
-* address feedback pt 3
-
-* fix macros
-
-* refactor macro
-
-* address minor nits
-
-* fix brackets
+This means we also change the way we get the default locale. We go from getting only the locale and region, to getting the full thing.
 
 diff --git a/icu/icu4c/source/common/common.vcxproj b/icu/icu4c/source/common/common.vcxproj
 index f8f28ad768ca2b4e7ec93893b213c3b426f294c1..305b705430837c9c928690bf1fd5aa46de81d5fd 100644


### PR DESCRIPTION


<!--
Thanks for creating a pull request! We appreciate you taking the time to contribute!

Please note that this is a fork of ICU that contains changes for the following:
- Maintenance related changes.
- Changes that are required for usage internal to Microsoft.
- Changes that are needed for the Windows OS build of ICU.
- Changes to address the set of locales provided by Windows NLS compared to ICU.

Before creating any pull request, please ensure that your change is related to one of the above reasons.

Most other changes, bug fixes, improvements, enhancements, etc. should be made in the upstream project here:
https://github.com/unicode-org/icu

-->

<!-- Enter a brief description/summary of your PR here. What does it fix, what does it change, how was it tested... -->
## Summary
I'm adding a patch file to be able to keep the changes done in https://github.com/microsoft/icu/pull/112 This added the uprefs preference override library that will allow you to get the default locale as a BCP 47 tag.

For some reason I can't see the diffs in this PR, but I can see the file itself in the branch -> 
https://github.com/microsoft/icu/blob/user/ertorres/add-patch-for-library/icu-patches/patches/020-MSFT-Patch_ICU_Add_uprefs_library_to_obtain_default_locale_as_full_BCP47_tag.patch
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [x] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description
