### PR TITLE
Update guava dependency to 32.1.1 (latest) to fix vulnerabilitites

### DIFF
--- a/icu/tools/cldr/cldr-to-icu/pom.xml
+++ b/icu/tools/cldr/cldr-to-icu/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.1.1-jre</version>
         </dependency>
 
         <!-- Ant: Only used for running the conversion tool, not compiling it. -->


### PR DESCRIPTION
This PR attempts to fix vulnerabilities found in the [CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976). by updating the guava dependency version to 32.1.1 (latest available).

Note: An earlier automated PR also tried to do the same but it updates to 32.0.0 which has some issues on windows builds.
Thus, updating to latest version available
<!--
Thanks for creating a pull request! We appreciate you taking the time to contribute!

Please note that this is a fork of ICU that contains changes for the following:
- Maintenance related changes.
- Changes that are required for usage internal to Microsoft.
- Changes that are needed for the Windows OS build of ICU.
- Changes to address the set of locales provided by Windows NLS compared to ICU.

Before creating any pull request, please ensure that your change is related to one of the above reasons.

Most other changes, bug fixes, improvements, enhancements, etc. should be made in the upstream project here:
https://github.com/unicode-org/icu

-->

<!-- Enter a brief description/summary of your PR here. What does it fix, what does it change, how was it tested... -->
## Summary

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [x] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description
