### PR TITLE
Revert treatment of '@' as ALetter for word break

### DIFF
--- a/icu/icu4c/source/data/brkitr/rules/word.txt
+++ b/icu/icu4c/source/data/brkitr/rules/word.txt
@@ -38,7 +38,7 @@ $Regional_Indicator = [\p{Word_Break = Regional_Indicator}];
 $Format             = [\p{Word_Break = Format}];
 $Katakana           = [\p{Word_Break = Katakana}];
 $Hebrew_Letter      = [\p{Word_Break = Hebrew_Letter}];
-$ALetter            = [\p{Word_Break = ALetter} @];
+$ALetter            = [\p{Word_Break = ALetter}];
 $Single_Quote       = [\p{Word_Break = Single_Quote}];
 $Double_Quote       = [\p{Word_Break = Double_Quote}];
 $MidNumLet          = [\p{Word_Break = MidNumLet}];

--- a/icu/icu4c/source/data/brkitr/rules/word_POSIX.txt
+++ b/icu/icu4c/source/data/brkitr/rules/word_POSIX.txt
@@ -38,7 +38,7 @@ $Regional_Indicator = [\p{Word_Break = Regional_Indicator}];
 $Format             = [\p{Word_Break = Format}];
 $Katakana           = [\p{Word_Break = Katakana}];
 $Hebrew_Letter      = [\p{Word_Break = Hebrew_Letter}];
-$ALetter            = [\p{Word_Break = ALetter} @];
+$ALetter            = [\p{Word_Break = ALetter}];
 $Single_Quote       = [\p{Word_Break = Single_Quote}];
 $Double_Quote       = [\p{Word_Break = Double_Quote}];
 $MidNumLet          = [\p{Word_Break = MidNumLet} - [.]];

--- a/icu/icu4c/source/data/brkitr/rules/word_fi_sv.txt
+++ b/icu/icu4c/source/data/brkitr/rules/word_fi_sv.txt
@@ -38,7 +38,7 @@ $Regional_Indicator = [\p{Word_Break = Regional_Indicator}];
 $Format             = [\p{Word_Break = Format}];
 $Katakana           = [\p{Word_Break = Katakana}];
 $Hebrew_Letter      = [\p{Word_Break = Hebrew_Letter}];
-$ALetter            = [\p{Word_Break = ALetter} @];
+$ALetter            = [\p{Word_Break = ALetter}];
 $Single_Quote       = [\p{Word_Break = Single_Quote}];
 $Double_Quote       = [\p{Word_Break = Double_Quote}];
 $MidNumLet          = [\p{Word_Break = MidNumLet}];

--- a/icu/icu4c/source/test/intltest/rbbitst.cpp
+++ b/icu/icu4c/source/test/intltest/rbbitst.cpp
@@ -1917,7 +1917,7 @@ RBBIWordMonkey::RBBIWordMonkey()
     fKatakanaSet      = new UnicodeSet(u"[\\p{Word_Break = Katakana}]",     status);
     fRegionalIndicatorSet =  new UnicodeSet(u"[\\p{Word_Break = Regional_Indicator}]", status);
     fHebrew_LetterSet = new UnicodeSet(u"[\\p{Word_Break = Hebrew_Letter}]", status);
-    fALetterSet       = new UnicodeSet(u"[\\p{Word_Break = ALetter} @]", status);
+    fALetterSet       = new UnicodeSet(u"[\\p{Word_Break = ALetter}]", status);
     fSingle_QuoteSet  = new UnicodeSet(u"[\\p{Word_Break = Single_Quote}]",    status);
     fDouble_QuoteSet  = new UnicodeSet(u"[\\p{Word_Break = Double_Quote}]",    status);
     fMidNumLetSet     = new UnicodeSet(u"[\\p{Word_Break = MidNumLet}]",    status);

--- a/icu/icu4c/source/test/testdata/break_rules/word.txt
+++ b/icu/icu4c/source/test/testdata/break_rules/word.txt
@@ -25,7 +25,7 @@ Regional_Indicator = [\p{Word_Break = Regional_Indicator}];
 Format             = [\p{Word_Break = Format}];
 Katakana           = [\p{Word_Break = Katakana}];
 Hebrew_Letter      = [\p{Word_Break = Hebrew_Letter}];
-ALetter            = [\p{Word_Break = ALetter} @];
+ALetter            = [\p{Word_Break = ALetter}];
 Single_Quote       = [\p{Word_Break = Single_Quote}];
 Double_Quote       = [\p{Word_Break = Double_Quote}];
 MidNumLet          = [\p{Word_Break = MidNumLet}];

--- a/icu/icu4c/source/test/testdata/rbbitst.txt
+++ b/icu/icu4c/source/test/testdata/rbbitst.txt
@@ -1586,7 +1586,7 @@ Bangkok)•</data>
 <data>•Can't<200> •have<200> •breaks<200> •in<200> •xx<200>:•yy<200> •or<200> •struct.field<200> \
 •for<200> •CS<200>-•types<200>.•</data>
 <data>•\uFF92\uFF76\uFF9E<400> •</data>
-<data>•xx@yy<200>.•</data>
+<data>•xx<200>@•yy<200>.•</data>
 
 <locale en_US_POSIX>
 <word>
@@ -1594,21 +1594,21 @@ Bangkok)•</data>
 •for<200> •CS<200>-•types<200>.•</data>
 <data>•\u06c9<200>\uc799\ufffa•</data>
 <data>•\uFF92\uFF76\uFF9E<400> •</data>
-<data>•xx@yy<200>.•</data>
+<data>•xx<200>@•yy<200>.•</data>
 
 <locale fi>
 <word>
 <data>•Can't<200> •have<200> •breaks<200> •in<200> •xx:yy<200> •or<200> •struct.field<200> \
 •for<200> •CS<200>-•types<200>.•</data>
 <data>•\uFF92\uFF76\uFF9E<400> •</data>
-<data>•xx@yy<200>.•</data>
+<data>•xx<200>@•yy<200>.•</data>
 
 <locale sv>
 <word>
 <data>•Can't<200> •have<200> •breaks<200> •in<200> •xx:yy<200> •or<200> •struct.field<200> \
 •for<200> •CS<200>-•types<200>.•</data>
 <data>•\uFF92\uFF76\uFF9E<400> •</data>
-<data>•xx@yy<200>.•</data>
+<data>•xx<200>@•yy<200>.•</data>
 
 
 # UBreakIteratorType UBRK_CHARACTER, Locale "th"


### PR DESCRIPTION
Cherry-picked from https://github.com/unicode-org/icu/pull/2460/files

The ICU 72 change to treat '@' as ALetter for word break could cause significant compatibility problems (for instance @-mentions in Twitter and other apps stopped working).
This reverts that change

<!--
Thanks for creating a pull request! We appreciate you taking the time to contribute!

Please note that this is a fork of ICU that contains changes for the following:
- Maintenance related changes.
- Changes that are required for usage internal to Microsoft.
- Changes that are needed for the Windows OS build of ICU.
- Changes to address the set of locales provided by Windows NLS compared to ICU.

Before creating any pull request, please ensure that your change is related to one of the above reasons.

Most other changes, bug fixes, improvements, enhancements, etc. should be made in the upstream project here:
https://github.com/unicode-org/icu

-->

<!-- Enter a brief description/summary of your PR here. What does it fix, what does it change, how was it tested... -->
## Summary

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [x] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description
