### PR TITLE
Disable the dynamic plug-in loading and update to v72.1.0.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 ## ICU 72.1.0.3
 
 - Disable the dynamic plug-in loading due to security concerns
-- Add changes to emit COdeView debugging information to PDB/object files.
+- Add changes to emit debugging information to PDB/object files.
 
 ## ICU 72.1.0.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,9 @@
 # Changelog
+## ICU 72.1.0.3
+
+- Disable the dynamic plug-in loading due to security concerns
+- Add changes to emit COdeView debugging information to PDB/object files.
+
 ## ICU 72.1.0.2
 
 - Restore NNBSP with ASCII space for English locales

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 
 - Disable the dynamic plug-in loading due to security concerns
 - Add changes to emit debugging information to PDB/object files.
-
+- Add changes to enable COMDAT folding and elimination when linking.
 ## ICU 72.1.0.2
 
 - Restore NNBSP with ASCII space for English locales

--- a/icu/icu4c/source/allinone/Build.Windows.ProjectConfiguration.props
+++ b/icu/icu4c/source/allinone/Build.Windows.ProjectConfiguration.props
@@ -111,10 +111,11 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </Midl>
     <ClCompile>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;U_ENABLE_DYLOAD=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/Zi %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -122,6 +123,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalOptions>/profile /opt:ref /opt:icf %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <!-- Options that are common to all 'Debug' configurations for *all* projects. -->

--- a/icu/icu4c/source/common/unicode/uvernum.h
+++ b/icu/icu4c/source/common/unicode/uvernum.h
@@ -72,7 +72,7 @@
  *  @stable ICU 4.0
  */
 #ifndef U_ICU_VERSION_BUILDLEVEL_NUM
-#define U_ICU_VERSION_BUILDLEVEL_NUM 2
+#define U_ICU_VERSION_BUILDLEVEL_NUM 3
 #endif
 
 /** Glued version suffix for renamers
@@ -132,7 +132,7 @@
  *  This value will change in the subsequent releases of ICU
  *  @stable ICU 2.4
  */
-#define U_ICU_VERSION "72.1.0.2"
+#define U_ICU_VERSION "72.1.0.3"
 
 /**
  * The current ICU library major version number as a string, for library name suffixes.
@@ -151,7 +151,7 @@
 /** Data version in ICU4C.
  * @internal ICU 4.4 Internal Use Only
  **/
-#define U_ICU_DATA_VERSION "72.1.0.2"
+#define U_ICU_DATA_VERSION "72.1.0.3"
 #endif  /* U_HIDE_INTERNAL_API */
 
 /*===========================================================================

--- a/version.txt
+++ b/version.txt
@@ -35,5 +35,5 @@
 # in the header file "uvernum.h" whenever updated and/or changed.
 #
 
-ICU_version = 72.1.0.2
+ICU_version = 72.1.0.3
 ICU_upstream_hash = 6046af063ddd7ed9cbab601a3c6304ad9070545d


### PR DESCRIPTION
We are disabling the plug-in loading capability for MS-ICU due to security concerns.

<!--
Thanks for creating a pull request! We appreciate you taking the time to contribute!

Please note that this is a fork of ICU that contains changes for the following:
- Maintenance related changes.
- Changes that are required for usage internal to Microsoft.
- Changes that are needed for the Windows OS build of ICU.
- Changes to address the set of locales provided by Windows NLS compared to ICU.

Before creating any pull request, please ensure that your change is related to one of the above reasons.

Most other changes, bug fixes, improvements, enhancements, etc. should be made in the upstream project here:
https://github.com/unicode-org/icu

-->

<!-- Enter a brief description/summary of your PR here. What does it fix, what does it change, how was it tested... -->
## Summary

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [x] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description
