### PR TITLE
Fix ESRP signing auth and release CFG settings

### DIFF
--- a/build/azure-nuget-1es-pt.yml
+++ b/build/azure-nuget-1es-pt.yml
@@ -494,13 +494,9 @@ extends:
             Write-Host "$(BUILD.ArtifactStagingDirectory)"
             Tree /F /A $(BUILD.ArtifactStagingDirectory)
           displayName: 'DIAG: dir'
-        
-        - powershell: |
-            Write-Host "SigningPattern is: '$(signingPattern)'" 
-          displayName: 'DIAG: show signing pattern'
 
         - task: EsrpCodeSigning@5
-          displayName: 'ESRP CodeSigning - CodeSign DLLs'
+          displayName: 'ESRP CodeSigning - CodeSign NuGet'
           inputs:
             ConnectedServiceName: 'ESRP Code Signing for MS-ICU (2026)'
             UseMSIAuthentication: true

--- a/build/azure-nuget-1es-pt.yml
+++ b/build/azure-nuget-1es-pt.yml
@@ -320,6 +320,7 @@ extends:
             AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
             EsrpClientId: "8bc7108f-a254-4863-8e93-175eedff03cc"
             AuthAKVName: 'icukv'
+            AuthCertName: 'msicuesrp'
             AuthSignCertName: 'msicuesrp'
             FolderPath: '$(BUILD.ArtifactStagingDirectory)\bits\binaries-$(BuildPlatform)'
             Pattern: '*.dll'
@@ -504,6 +505,7 @@ extends:
             AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
             EsrpClientId: "8bc7108f-a254-4863-8e93-175eedff03cc"
             AuthAKVName: 'icukv'
+            AuthCertName: 'msicuesrp'
             AuthSignCertName: 'msicuesrp'
             FolderPath: '$(BUILD.ArtifactStagingDirectory)\nuget\Nuget_Packages'
             Pattern: |

--- a/build/azure-nuget-1es-pt.yml
+++ b/build/azure-nuget-1es-pt.yml
@@ -320,7 +320,6 @@ extends:
             AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
             EsrpClientId: "8bc7108f-a254-4863-8e93-175eedff03cc"
             AuthAKVName: 'icukv'
-            AuthCertName: 'msicuesrp'
             AuthSignCertName: 'msicuesrp'
             FolderPath: '$(BUILD.ArtifactStagingDirectory)\bits\binaries-$(BuildPlatform)'
             Pattern: '*.dll'
@@ -505,7 +504,6 @@ extends:
             AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
             EsrpClientId: "8bc7108f-a254-4863-8e93-175eedff03cc"
             AuthAKVName: 'icukv'
-            AuthCertName: 'msicuesrp'
             AuthSignCertName: 'msicuesrp'
             FolderPath: '$(BUILD.ArtifactStagingDirectory)\nuget\Nuget_Packages'
             Pattern: |

--- a/build/azure-nuget-1es-pt.yml
+++ b/build/azure-nuget-1es-pt.yml
@@ -266,7 +266,7 @@ extends:
       - job: CodeSignBits
         timeoutInMinutes: 60
         pool:
-          name: Azure-Pipelines-1ESPT-ExDShared
+          name: Azure-Pipelines-1ESPT-ExDShared-StaticIP
           os: windows
           image: windows-2022
         workspace:
@@ -461,7 +461,7 @@ extends:
       - job: CodeSignNugetJob
         timeoutInMinutes: 60
         pool:
-          name: Azure-Pipelines-1ESPT-ExDShared
+          name: Azure-Pipelines-1ESPT-ExDShared-StaticIP
           os: windows
           image: windows-2022
         workspace:

--- a/build/azure-nuget-1es-pt.yml
+++ b/build/azure-nuget-1es-pt.yml
@@ -591,5 +591,3 @@ extends:
           # To work around this issue, we just force LIB to be any dir that we know exists.
           env:
             LIB: $(Build.SourcesDirectory)
-            ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
-            ArtifactServices_Symbol_PAT: $(MSICU_microsoftpublicsymbols_PAT)

--- a/icu/icu4c/source/allinone/Build.Windows.ProjectConfiguration.props
+++ b/icu/icu4c/source/allinone/Build.Windows.ProjectConfiguration.props
@@ -116,6 +116,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalOptions>/Zi %(AdditionalOptions)</AdditionalOptions>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -123,7 +124,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-      <AdditionalOptions>/profile /opt:ref /opt:icf %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/guard:cf /profile /opt:ref /opt:icf %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <!-- Options that are common to all 'Debug' configurations for *all* projects. -->


### PR DESCRIPTION
## Summary
- switch code-signing jobs to the static IP 1ES pool
- set AuthCertName for ESRP signing tasks and remove legacy symbol PAT env vars
- enable Control Flow Guard (/guard:cf) for release allinone builds

## Purpose
Align signing/auth configuration and release hardening settings for the pipeline.