### PR TITLE
User/aoruganti/fix symbol publish auth

### DIFF
--- a/build/azure-nuget-1es-pt.yml
+++ b/build/azure-nuget-1es-pt.yml
@@ -494,13 +494,9 @@ extends:
             Write-Host "$(BUILD.ArtifactStagingDirectory)"
             Tree /F /A $(BUILD.ArtifactStagingDirectory)
           displayName: 'DIAG: dir'
-        
-        - powershell: |
-            Write-Host "SigningPattern is: '$(signingPattern)'" 
-          displayName: 'DIAG: show signing pattern'
 
         - task: EsrpCodeSigning@5
-          displayName: 'ESRP CodeSigning - CodeSign DLLs'
+          displayName: 'ESRP CodeSigning - CodeSign NuGet'
           inputs:
             ConnectedServiceName: 'ESRP Code Signing for MS-ICU (2026)'
             UseMSIAuthentication: true

--- a/build/azure-nuget-1es-pt.yml
+++ b/build/azure-nuget-1es-pt.yml
@@ -320,6 +320,7 @@ extends:
             AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
             EsrpClientId: "8bc7108f-a254-4863-8e93-175eedff03cc"
             AuthAKVName: 'icukv'
+            AuthCertName: 'msicuesrp'
             AuthSignCertName: 'msicuesrp'
             FolderPath: '$(BUILD.ArtifactStagingDirectory)\bits\binaries-$(BuildPlatform)'
             Pattern: '*.dll'
@@ -504,6 +505,7 @@ extends:
             AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
             EsrpClientId: "8bc7108f-a254-4863-8e93-175eedff03cc"
             AuthAKVName: 'icukv'
+            AuthCertName: 'msicuesrp'
             AuthSignCertName: 'msicuesrp'
             FolderPath: '$(BUILD.ArtifactStagingDirectory)\nuget\Nuget_Packages'
             Pattern: |

--- a/build/azure-nuget-1es-pt.yml
+++ b/build/azure-nuget-1es-pt.yml
@@ -320,7 +320,6 @@ extends:
             AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
             EsrpClientId: "8bc7108f-a254-4863-8e93-175eedff03cc"
             AuthAKVName: 'icukv'
-            AuthCertName: 'msicuesrp'
             AuthSignCertName: 'msicuesrp'
             FolderPath: '$(BUILD.ArtifactStagingDirectory)\bits\binaries-$(BuildPlatform)'
             Pattern: '*.dll'
@@ -505,7 +504,6 @@ extends:
             AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
             EsrpClientId: "8bc7108f-a254-4863-8e93-175eedff03cc"
             AuthAKVName: 'icukv'
-            AuthCertName: 'msicuesrp'
             AuthSignCertName: 'msicuesrp'
             FolderPath: '$(BUILD.ArtifactStagingDirectory)\nuget\Nuget_Packages'
             Pattern: |

--- a/build/azure-nuget-1es-pt.yml
+++ b/build/azure-nuget-1es-pt.yml
@@ -266,7 +266,7 @@ extends:
       - job: CodeSignBits
         timeoutInMinutes: 60
         pool:
-          name: Azure-Pipelines-1ESPT-ExDShared
+          name: Azure-Pipelines-1ESPT-ExDShared-StaticIP
           os: windows
           image: windows-2022
         workspace:
@@ -461,7 +461,7 @@ extends:
       - job: CodeSignNugetJob
         timeoutInMinutes: 60
         pool:
-          name: Azure-Pipelines-1ESPT-ExDShared
+          name: Azure-Pipelines-1ESPT-ExDShared-StaticIP
           os: windows
           image: windows-2022
         workspace:

--- a/build/azure-nuget-1es-pt.yml
+++ b/build/azure-nuget-1es-pt.yml
@@ -591,5 +591,3 @@ extends:
           # To work around this issue, we just force LIB to be any dir that we know exists.
           env:
             LIB: $(Build.SourcesDirectory)
-            ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
-            ArtifactServices_Symbol_PAT: $(MSICU_microsoftpublicsymbols_PAT)

--- a/icu/icu4c/source/allinone/Build.Windows.ProjectConfiguration.props
+++ b/icu/icu4c/source/allinone/Build.Windows.ProjectConfiguration.props
@@ -116,6 +116,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalOptions>/Zi %(AdditionalOptions)</AdditionalOptions>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -123,7 +124,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-      <AdditionalOptions>/profile /opt:ref /opt:icf %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/guard:cf /profile /opt:ref /opt:icf %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <!-- Options that are common to all 'Debug' configurations for *all* projects. -->


### PR DESCRIPTION
## Summary
 
 Fix Azure DevOps signing pipeline (auth, ESRP cert, build pool) and pick up CFG build change via merge.
 
 ## PR Checklist
 - [x] Verified this change cannot be made upstream.
 - [x] Maintenance change.
 - [x] Microsoft-internal usage.
 - [ ] Windows OS build of ICU.
 - [ ] CLA signed.
 
 ## Detailed Description
 
 **`build/azure-nuget-1es-pt.yml`**
 - **Symbol publish auth:** removed expired `MSICU_microsoftpublicsymbols_PAT`; `PublishSymbols@2` now uses the 
pipeline's built-in OAuth token.
 - **ESRP code signing:** added missing `AuthCertName: 'msicuesrp'` to both `CodeSignBits` and `CodeSignNugetJob` 
(required alongside `AuthSignCertName` for AAD auth to ESRP).
 - **Build pool:** switched both signing jobs to `Azure-Pipelines-1ESPT-ExDShared-StaticIP` so requests come from an 
ESRP-allow-listed IP range.